### PR TITLE
fix by H0zen - Arcane Missile self cast bug

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4293,6 +4293,11 @@ SpellCastResult Spell::CheckCast(bool strict)
         {
             if (m_caster->GetTypeId() == TYPEID_PLAYER && m_caster->IsInWorld())
             {
+                // Arcane Missile self cast forbidden
+                if (m_spellInfo->SpellFamilyName == SPELLFAMILY_MAGE &&
+                    m_spellInfo->SpellFamilyFlags & UI64LIT(0x0200800))
+                       { return SPELL_FAILED_BAD_TARGETS; }
+
                 // Additional check for some spells
                 // If 0 spell effect empty - client not send target data (need use selection)
                 // TODO: check it on next client version


### PR DESCRIPTION
Fix required here on One as well as Zero (where this was taken).

Will check the other cores to see if they also need the fix.

Note: a different mask is required for One to what Zero used (see
Spell.dbc and SpellFamilyFlags)
