### PR TITLE
Fix server crash when NPC pets die due to periodic damage auras.

### DIFF
--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -576,8 +576,8 @@ void Pet::Update(uint32 update_diff, uint32 diff)
             {
                 MANGOS_ASSERT(getPetType() != SUMMON_PET);  // Pet must be already removed
                 Unsummon(PET_SAVE_NOT_IN_SLOT);             // hunters' pets never get removed because of death, NEVER!
-                break;
             }
+            break;
         }
         case ALIVE:
         {


### PR DESCRIPTION
Note: does not apply to Zero!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/50)

<!-- Reviewable:end -->
