### PR TITLE
Fix some startup (fake) errors

### DIFF
--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -1192,17 +1192,21 @@ bool Pet::InitStatsForLevel(uint32 petlevel, Unit* owner)
             }
             else                                            // not exist in DB, use some default fake data
             {
-                sLog.outErrorDb("Summoned pet (Entry: %u) not have pet stats data in DB", cinfo->Entry);
 
                 // remove elite bonuses included in DB values
                 SetCreateHealth(uint32(((float(cinfo->MaxLevelHealth) / cinfo->MaxLevel) / (1 + 2 * cinfo->Rank)) * petlevel));
                 SetCreateMana(uint32(((float(cinfo->MaxLevelMana)   / cinfo->MaxLevel) / (1 + 2 * cinfo->Rank)) * petlevel));
 
-                SetCreateStat(STAT_STRENGTH, 22);
-                SetCreateStat(STAT_AGILITY, 22);
-                SetCreateStat(STAT_STAMINA, 25);
-                SetCreateStat(STAT_INTELLECT, 28);
-                SetCreateStat(STAT_SPIRIT, 27);
+                if (owner->GetTypeId() == TYPEID_PLAYER)
+                {
+                    sLog.outErrorDb("Summoned pet (entry: %u, summoner: %s) does not have pet stats data in DB", cinfo->Entry, owner->GetGuidStr().c_str());
+
+                    SetCreateStat(STAT_STRENGTH, 22);
+                    SetCreateStat(STAT_AGILITY, 22);
+                    SetCreateStat(STAT_STAMINA, 25);
+                    SetCreateStat(STAT_INTELLECT, 28);
+                    SetCreateStat(STAT_SPIRIT, 27);
+                }
             }
             break;
         }


### PR DESCRIPTION
-Pets summoned by creatures do not need to have data in pet_levelstats table

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/53)

<!-- Reviewable:end -->
