### PR TITLE
Fix removal of cast bar when triggering spells.

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -3488,6 +3488,9 @@ void Spell::SendSpellGo()
     if (IsRangedSpell())
         { castFlags |= CAST_FLAG_AMMO; }                        // arrows/bullets visual
 
+    if (m_triggeredByAuraSpell)
+        { castFlags |= CAST_FLAG_HIDDEN_COMBATLOG; }
+
     WorldPacket data(SMSG_SPELL_GO, 50);                    // guess size
 
     if (m_CastItem)


### PR DESCRIPTION
    - Fixes https://www.getmangos.eu/bug-tracker/mangos-one/cast-bar-disappears-r1337/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/65)
<!-- Reviewable:end -->
