### PR TITLE
Fix sending the right GAMEOBJECT_FACING field to the client.

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -1687,7 +1687,7 @@ void GameObject::SetQuaternion(G3D::Quat const& q)
     SetFloatValue(GAMEOBJECT_ROTATION + 1, q.y);
     SetFloatValue(GAMEOBJECT_ROTATION + 2, q.z);
     SetFloatValue(GAMEOBJECT_ROTATION + 3, q.w);
-
+    SetFloatValue(GAMEOBJECT_FACING, GetOrientationFromQuat(q));
     if (m_model)
       { m_model->UpdateRotation(q); }
 }


### PR DESCRIPTION
    - fixes https://www.getmangos.eu/bug-tracker/mangos-one/undercity-elevators-bug-r1341/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/66)
<!-- Reviewable:end -->
