### PR TITLE
GM chat badge (PlayerChatTag is a bitfield)

### DIFF
--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -68,10 +68,10 @@ enum ChatCommandSearchResult
 
 enum PlayerChatTag
 {
-    CHAT_TAG_NONE               = 0,
-    CHAT_TAG_AFK                = 1,
-    CHAT_TAG_DND                = 2,
-    CHAT_TAG_GM                 = 3,
+    CHAT_TAG_NONE               = 0x0,
+    CHAT_TAG_AFK                = 0x1,
+    CHAT_TAG_DND                = 0x2,
+    CHAT_TAG_GM                 = 0x4,
 };
 typedef uint32 ChatTagFlags;
 


### PR DESCRIPTION
PlayerChatTag is a bitfield actually, and as such one is used everywhere.
Closing [this report](https://www.getmangos.eu/bug-tracker/mangos-one/gm-chat-badge-r1414/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/68)
<!-- Reviewable:end -->
