### PR TITLE
Triggered spells do not consume power - missed part

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -5734,6 +5734,10 @@ uint32 Spell::CalculatePowerCost(SpellEntry const* spellInfo, Unit* caster, Spel
 
 SpellCastResult Spell::CheckPower()
 {
+    // triggered spell use no power
+    if (m_IsTriggeredSpell)
+        return SPELL_CAST_OK;
+
     // item cast not used power
     if (m_CastItem)
         { return SPELL_CAST_OK; }


### PR DESCRIPTION
A missed part of the 898fcf4 commit. Now the triggered spellcast is enabled properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/71)
<!-- Reviewable:end -->
