### PR TITLE
An implementation of the GO casting

### DIFF
--- a/src/framework/GameSystem/TypeContainer.h
+++ b/src/framework/GameSystem/TypeContainer.h
@@ -206,8 +206,8 @@ class TypeUnorderedMapContainer
          */
         static SPECIFIC_TYPE* find(ContainerUnorderedMap<SPECIFIC_TYPE, KEY_TYPE>& elements, KEY_TYPE hdl, SPECIFIC_TYPE* /*obj*/)
         {
-            typename UNORDERED_MAP<KEY_TYPE, SPECIFIC_TYPE*>::iterator i = elements._element.find(hdl);
-            if (i == elements._element.end())
+            typename UNORDERED_MAP<KEY_TYPE, SPECIFIC_TYPE*>::const_iterator i = elements._element.find(hdl);
+            if (i == elements._element.cend())
                 { return NULL; }
             else
                 { return i->second; }

--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -2698,18 +2698,21 @@ uint32 GameObject::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* c
                 pVictim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DIRECT_DAMAGE);
         }
 
-        // Rage from damage received
-        if (pVictim->GetPowerType() == POWER_RAGE)
+        if (pVictim->GetTypeId() == TYPEID_PLAYER)
         {
-            uint32 rage_damage = damage + (cleanDamage ? cleanDamage->damage : 0);
-            ((Player*)pVictim)->RewardRage(rage_damage, 0, false);
-        }
+            // Rage from damage received
+            if (pVictim->GetPowerType() == POWER_RAGE)
+            {
+                uint32 rage_damage = damage + (cleanDamage ? cleanDamage->damage : 0);
+                ((Player*)pVictim)->RewardRage(rage_damage, 0, false);
+            }
 
-        // random durability for items (HIT TAKEN)
-        if (roll_chance_f(sWorld.getConfig(CONFIG_FLOAT_RATE_DURABILITY_LOSS_DAMAGE)))
-        {
-            EquipmentSlots slot = EquipmentSlots(urand(0, EQUIPMENT_SLOT_END - 1));
-            ((Player*)pVictim)->DurabilityPointLossForEquipSlot(slot);
+            // random durability for items (HIT TAKEN)
+            if (roll_chance_f(sWorld.getConfig(CONFIG_FLOAT_RATE_DURABILITY_LOSS_DAMAGE)))
+            {
+                EquipmentSlots slot = EquipmentSlots(urand(0, EQUIPMENT_SLOT_END - 1));
+                ((Player*)pVictim)->DurabilityPointLossForEquipSlot(slot);
+            }
         }
 
         pVictim->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_DAMAGE, spellProto ? spellProto->Id : 0);

--- a/src/game/Object/GameObject.h
+++ b/src/game/Object/GameObject.h
@@ -740,6 +740,21 @@ class GameObject : public WorldObject
 
         GameObjectModel* m_model;
 
+        // object casting implementation
+        SpellMissInfo MagicSpellHitResult(Unit* pVictim, SpellEntry const* spell) override;
+        SpellMissInfo SpellHitResult(Unit* pVictim, SpellEntry const* spell, bool canReflect = false) override;
+        bool IsSpellCrit(WorldObject* pVictim, SpellEntry const* spellProto, SpellSchoolMask schoolMask, WeaponAttackType /*attackType = BASE_ATTACK*/) override;
+        uint32 SpellCriticalDamageBonus(SpellEntry const* spellProto, uint32 damage, Unit* pVictim) override;
+        int32 CalculateSpellDamage(ObjectGuid const targetGUID, SpellEntry const* spellProto, SpellEffectIndex effect_index, int32 const* basePoints = NULL) override;
+        void CalculateSpellDamage(SpellNonMeleeDamage* damageInfo, int32 damage, SpellEntry const* spellInfo, WeaponAttackType attackType = BASE_ATTACK) override;
+        uint32 DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDamage, DamageEffectType damagetype, SpellSchoolMask damageSchoolMask, SpellEntry const* spellProto, bool durabilityLoss) override;
+
+        void CastSpell(Unit* Victim, uint32 spellId, bool triggered = true, Item* castItem = NULL, Aura* triggeredByAura = NULL, ObjectGuid relatedObjectGUID = ObjectGuid(), SpellEntry const* triggeredBy = NULL) override;
+        void CastSpell(Unit* Victim, SpellEntry const* spellInfo, bool triggered = true, Item* castItem = NULL, Aura* triggeredByAura = NULL, ObjectGuid originalCaster = ObjectGuid(), SpellEntry const* triggeredBy = NULL) override;
+        void CastSpell(float x, float y, float z, uint32 spellId, bool triggered = true, Item* castItem = NULL, Aura* triggeredByAura = NULL, ObjectGuid originalCaster = ObjectGuid(), SpellEntry const* triggeredBy = NULL) override;
+        void CastSpell(float x, float y, float z, SpellEntry const* spellInfo, bool triggered = true, Item* castItem = NULL, Aura* triggeredByAura = NULL, ObjectGuid originalCaster = ObjectGuid(), SpellEntry const* triggeredBy = NULL) override;
+        void CastSpell(Unit* Victim, uint32 spellId, ObjectGuid relatedUnit = ObjectGuid());
+
     protected:
         uint32      m_spellId;
         time_t      m_respawnTime;                          // (secs) time of next respawn (or despawn if GO have owner()),

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1585,7 +1585,7 @@ class Player : public Unit
         bool IsNeedCastPassiveLikeSpellAtLearn(SpellEntry const* spellInfo) const;
         bool IsImmuneToSpellEffect(SpellEntry const* spellInfo, SpellEffectIndex index, bool castOnSelf) const override;
 
-        void KnockBackFrom(Unit* target, float horizontalSpeed, float verticalSpeed);
+        void KnockBackFrom(WorldObject* target, float horizontalSpeed, float verticalSpeed);
 
         void SendProficiency(ItemClass itemClass, uint32 itemSubclassMask);
         void SendInitialSpells();
@@ -2303,6 +2303,8 @@ class Player : public Unit
         void RemoveAtLoginFlag(AtLoginFlags f, bool in_db_also = false);
 
         LookingForGroup m_lookingForGroup;
+
+        bool ActivateSpiritOfRedemption();      // true if talent was activated
 
         // Temporarily removed pet cache
         uint32 GetTemporaryUnsummonedPetNumber() const { return m_temporaryUnsummonedPetNumber; }

--- a/src/game/Object/SpellMgr.h
+++ b/src/game/Object/SpellMgr.h
@@ -93,7 +93,7 @@ inline float GetSpellMaxRange(SpellRangeEntry const* range) { return (range ? ra
 inline uint32 GetSpellRecoveryTime(SpellEntry const* spellInfo) { return spellInfo->RecoveryTime > spellInfo->CategoryRecoveryTime ? spellInfo->RecoveryTime : spellInfo->CategoryRecoveryTime; }
 int32 GetSpellDuration(SpellEntry const* spellInfo);
 int32 GetSpellMaxDuration(SpellEntry const* spellInfo);
-int32 CalculateSpellDuration(SpellEntry const* spellInfo, Unit const* caster = NULL);
+int32 CalculateSpellDuration(SpellEntry const* spellInfo, WorldObject const* caster = NULL);
 uint16 GetSpellAuraMaxTicks(SpellEntry const* spellInfo);
 uint16 GetSpellAuraMaxTicks(uint32 spellId);
 WeaponAttackType GetWeaponAttackType(SpellEntry const* spellInfo);

--- a/src/game/Server/Opcodes.h
+++ b/src/game/Server/Opcodes.h
@@ -461,7 +461,7 @@ enum Opcodes
     SMSG_QUESTUPDATE_FAILEDTIMER                    = 0x197,
     SMSG_QUESTUPDATE_COMPLETE                       = 0x198,
     SMSG_QUESTUPDATE_ADD_KILL                       = 0x199,
-    SMSG_QUESTUPDATE_ADD_ITEM                       = 0x19A,
+    SMSG_QUESTUPDATE_ADD_ITEM                       = 0x19A,    // no parameters, no effect
     CMSG_QUEST_CONFIRM_ACCEPT                       = 0x19B,
     SMSG_QUEST_CONFIRM_ACCEPT                       = 0x19C,
     CMSG_PUSHQUESTTOPARTY                           = 0x19D,

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -243,12 +243,12 @@ class Map : public GridRefManager<NGridType>
         Player* GetPlayer(ObjectGuid guid);
         Creature* GetCreature(ObjectGuid guid);
         Pet* GetPet(ObjectGuid guid);
-        Creature* GetAnyTypeCreature(ObjectGuid guid);      // normal creature or pet or vehicle
+        Creature* GetAnyTypeCreature(ObjectGuid guid);    // normal creature or pet or vehicle
         GameObject* GetGameObject(ObjectGuid guid);
         DynamicObject* GetDynamicObject(ObjectGuid guid);
-        Corpse* GetCorpse(ObjectGuid guid);                 // !!! find corpse can be not in world
-        Unit* GetUnit(ObjectGuid guid);                     // only use if sure that need objects at current map, specially for player case
-        WorldObject* GetWorldObject(ObjectGuid guid);       // only use if sure that need objects at current map, specially for player case
+        Corpse* GetCorpse(ObjectGuid guid);               // !!! find corpse can be not in world
+        Unit* GetUnit(ObjectGuid guid);                   // only use if sure that need objects at current map, specially for player case
+        WorldObject* GetWorldObject(ObjectGuid guid);     // only use if sure that need objects at current map, specially for player case
 
         typedef TypeUnorderedMapContainer<AllMapStoredObjectTypes, ObjectGuid> MapStoredObjectTypesContainer;
         MapStoredObjectTypesContainer& GetObjectsStore() { return m_objectsStore; }

--- a/src/game/WorldHandlers/SpellHandler.cpp
+++ b/src/game/WorldHandlers/SpellHandler.cpp
@@ -362,7 +362,7 @@ void WorldSession::HandleCastSpellOpcode(WorldPacket& recvPacket)
     {
         // if rank not found then function return NULL but in explicit cast case original spell can be casted and later failed with appropriate error message
         if (SpellEntry const* actualSpellInfo = sSpellMgr.SelectAuraRankForLevel(spellInfo, target->getLevel()))
-            { spellInfo = actualSpellInfo; }
+            spellInfo = actualSpellInfo;
     }
 
     Spell* spell = new Spell(_player, spellInfo, false);

--- a/src/game/WorldHandlers/TradeHandler.cpp
+++ b/src/game/WorldHandlers/TradeHandler.cpp
@@ -342,8 +342,8 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& recvPacket)
                 return;
             }
 
-            my_spell = new Spell(_player, spellEntry, true);
-            my_spell->m_CastItem = castItem;
+            my_spell = new Spell(_player, spellEntry, true, castItem->GetObjectGuid());
+            //my_spell->m_CastItem = castItem;
             my_targets.setTradeItemTarget(_player);
             my_spell->m_targets = my_targets;
 
@@ -378,8 +378,8 @@ void WorldSession::HandleAcceptTradeOpcode(WorldPacket& recvPacket)
                 return;
             }
 
-            his_spell = new Spell(trader, spellEntry, true);
-            his_spell->m_CastItem = castItem;
+            his_spell = new Spell(trader, spellEntry, true, castItem->GetObjectGuid());
+            //his_spell->m_CastItem = castItem;
             his_targets.setTradeItemTarget(trader);
             his_spell->m_targets = his_targets;
 

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -1431,7 +1431,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                         return SPELL_AURA_PROC_FAILED;
                     }
 
-                    int32 extra_attack_power = CalculateSpellDamage(pVictim, windfurySpellEntry, EFFECT_INDEX_0);
+                    int32 extra_attack_power = CalculateSpellDamage(pVictim->GetObjectGuid(), windfurySpellEntry, EFFECT_INDEX_0);
 
                     // Off-Hand case
                     if (castItem->GetSlot() == EQUIPMENT_SLOT_OFFHAND)
@@ -2240,8 +2240,11 @@ SpellAuraProcResult Unit::HandleProcTriggerDamageAuraProc(Unit* pVictim, uint32 
                      triggeredByAura->GetModifier()->m_amount, spellInfo->Id, triggeredByAura->GetModifier()->m_auraname, triggeredByAura->GetId());
     SpellNonMeleeDamage damageInfo(this, pVictim, spellInfo->Id, SpellSchoolMask(spellInfo->SchoolMask));
     CalculateSpellDamage(&damageInfo, triggeredByAura->GetModifier()->m_amount, spellInfo);
-    damageInfo.target->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
-    DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
+    if (damageInfo.target->ToUnit())
+    {
+        damageInfo.target->ToUnit()->CalculateAbsorbResistBlock(this, &damageInfo, spellInfo);
+        DealDamageMods(damageInfo.target->ToUnit(), damageInfo.damage, &damageInfo.absorb);
+    }
     SendSpellNonMeleeDamageLog(&damageInfo);
     DealSpellDamage(&damageInfo, true);
     return SPELL_AURA_PROC_OK;


### PR DESCRIPTION
**Please do not merge this into the master branch!**

It (partially) supports aura generators.
This is a close-to-untested version. To be built, it also requires minor changes in the Eluna submodule (the diff follows).
[GOcasting_eluna.txt](https://github.com/mangosone/server/files/1220156/GOcasting_eluna.txt)

To reproduce the video, the following DB change is required before spawning some GOs 186396:

`UPDATE gameobject_template SET faction=35, data2=42490 WHERE entry=186396 AND faction=0 AND data2=42491;`

This change (must be reverted later) is due to the fact that GO auras, implied by the auragenerator spell 42491, are not supported (yet). Also, the casting chain 42491->42492->42490 is too long for testing and requires a scripted implementation of the 42492 spell as well.

Due to massive changes, an extensive testing is required, and crashes are probable enough.

2. Thanks to @Rochet2. Fix by more type checking. Please merge with the main update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/72)
<!-- Reviewable:end -->