### PR TITLE
Core mechanics required by quest 9718

### DIFF
--- a/src/game/WorldHandlers/ScriptMgr.cpp
+++ b/src/game/WorldHandlers/ScriptMgr.cpp
@@ -1561,11 +1561,13 @@ bool ScriptAction::HandleScriptStep()
         }
         case SCRIPT_COMMAND_MORPH_TO_ENTRY_OR_MODEL:        // 23
         {
-            if (LogIfNotCreature(pSource))
+            if (LogIfNotUnit(pSource))
                 { break; }
+            if (pSource->GetTypeId() == TYPEID_PLAYER && m_script->morph.creatureOrModelEntry)  // only demorph to players
+                break;
 
             if (!m_script->morph.creatureOrModelEntry)
-                { ((Creature*)pSource)->DeMorph(); }
+                { ((Unit*)pSource)->DeMorph(); }
             else if (m_script->data_flags & SCRIPT_FLAG_COMMAND_ADDITIONAL)
                 { ((Creature*)pSource)->SetDisplayId(m_script->morph.creatureOrModelEntry); }
             else

--- a/src/game/WorldHandlers/TaxiHandler.cpp
+++ b/src/game/WorldHandlers/TaxiHandler.cpp
@@ -211,7 +211,9 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recv_data)
     uint32 pathid = GetPlayer()->m_taxi.GetCurrentTaxiPath();
     TaxiPathNodeList const& nlist = sTaxiPathNodesByPath[pathid];
     if (uint32 eventid = nlist[nlist.size() - 1].arrivalEventID)
-        StartEvents_Event(GetPlayer()->GetMap(), eventid, GetPlayer(), GetPlayer());
+        if (!sScriptMgr.OnProcessEvent(eventid, GetPlayer(), GetPlayer(), false))
+            GetPlayer()->GetMap()->ScriptsStart(DBS_ON_EVENT, eventid, GetPlayer(), GetPlayer());
+
 
     // in taxi flight packet received in 2 case:
     // 1) end taxi path in far (multi-node) flight

--- a/src/game/WorldHandlers/TaxiHandler.cpp
+++ b/src/game/WorldHandlers/TaxiHandler.cpp
@@ -206,6 +206,13 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recv_data)
     recv_data >> Unused<uint32>();                          // unk
 
 
+    // a unit (player) path, like transport one, may contain arrive/departure events; signal the last node arrive here
+    // TODO find a way to send event for any path node? TODO is there a better way to get the last TaxiPathNodeEntry?
+    uint32 pathid = GetPlayer()->m_taxi.GetCurrentTaxiPath();
+    TaxiPathNodeList const& nlist = sTaxiPathNodesByPath[pathid];
+    if (uint32 eventid = nlist[nlist.size() - 1].arrivalEventID)
+        StartEvents_Event(GetPlayer()->GetMap(), eventid, GetPlayer(), GetPlayer());
+
     // in taxi flight packet received in 2 case:
     // 1) end taxi path in far (multi-node) flight
     // 2) switch from one map to other in case multi-map taxi path


### PR DESCRIPTION
**Please merge this into a single commit.**
Surely the mechanics are universal; they just are required to fix the "As the Crow Flies" quest properly.
1. Allow player demorph to DB scripts. For Source=Player, `SCRIPT_COMMAND_MORPH_TO_ENTRY_OR_MODEL` is allowed with modelId=0, i.e. to demorph only. For any other modelId value the command is ignored silently in player case.
2.  Fire arrival event for the last node of player taxi path on `CMSG_MOVE_SPLINE_DONE`. The TaxiPathNode.dbc contains the event IDs of events to be triggered at arrival and departure of the worldobject to/from the path point. At the end of taxi movement, client sends `CMSG_MOVE_SPLINE_DONE`. This handler is the place to trigger an arrival event, though for the last path node only. The event will be handled by a DB script for the 9718 quest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/73)
<!-- Reviewable:end -->