### PR TITLE
Interrupt bug on all spellcasting creatures

### DIFF
--- a/src/game/Object/CreatureAI.cpp
+++ b/src/game/Object/CreatureAI.cpp
@@ -60,6 +60,10 @@ CanCastResult CreatureAI::CanCastSpell(Unit* pTarget, const SpellEntry* pSpell, 
         // Check for power (also done by Spell::CheckCast())
         if (m_creature->GetPower((Powers)pSpell->powerType) < Spell::CalculatePowerCost(pSpell, m_creature))
             { return CAST_FAIL_POWER; }
+
+        // Spell school check; for the mobs, only non-triggered spells are affected
+        if (pSpell->SchoolMask && !m_creature->IsSchoolAllowed(SpellSchoolMask(pSpell->SchoolMask)))
+            return CAST_FAIL_STATE;
     }
 
     if (!m_creature->IsWithinLOSInMap(pTarget))

--- a/src/game/Object/CreatureAI.h
+++ b/src/game/Object/CreatureAI.h
@@ -68,7 +68,8 @@ enum CombatMovementFlags
     COMBAT_MOVEMENT_SCRIPT      = 0x01,                      // Combat movement enforced by script
     COMBAT_MOVEMENT_LOS         = 0x02,                      // Combat movement triggered by LoS issues
     COMBAT_MOVEMENT_OOM         = 0x04,                      // Combat movement triggered by power exhaustion
-    COMBAT_MOVEMENT_DISTANCE    = 0x08                       // Combat movement triggered by distance checks
+    COMBAT_MOVEMENT_DISTANCE    = 0x08,                      // Combat movement triggered by distance checks
+    COMBAT_MOVEMENT_SILENCE     = 0x10                       // Combat movement of a caster while silenced
 };
 
 enum AIEventType
@@ -318,7 +319,7 @@ class CreatureAI
         CanCastResult DoCastSpellIfCan(Unit* pTarget, uint32 uiSpell, uint32 uiCastFlags = 0, ObjectGuid OriginalCasterGuid = ObjectGuid());
 
         /// Combat movement functions
-        void SetCombatMovement(bool enable, bool stopOrStartMovement = false);
+        void SetCombatMovement(bool enable, bool stopOrStartMovement = true);
         bool IsCombatMovement() const { return m_combatMovement != 0; }
         void AddCombatMovementFlags(uint32 cmFlags);
         void ClearCombatMovementFlags(uint32 cmFlags);

--- a/src/game/Object/CreatureEventAI.cpp
+++ b/src/game/Object/CreatureEventAI.cpp
@@ -680,6 +680,9 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 case CAST_FAIL_NO_LOS:
                     cmFlags |= COMBAT_MOVEMENT_LOS;
                     break;
+                case CAST_FAIL_STATE:
+                    cmFlags |= COMBAT_MOVEMENT_SILENCE;
+                    break;
                 default:
                     break;
             }
@@ -690,18 +693,20 @@ void CreatureEventAI::ProcessAction(CreatureEventAI_Action const& action, uint32
                 if (!(action.cast.castFlags & CAST_NO_MELEE_IF_OOM))
                 {
                     AddCombatMovementFlags(cmFlags);
-                    SetCombatMovement(true,true);
+                    SetCombatMovement(true, true);
                 }
             }
             else
             {
-                if (m_combatMovement & (COMBAT_MOVEMENT_LOS | COMBAT_MOVEMENT_DISTANCE | COMBAT_MOVEMENT_OOM))
+                if (m_combatMovement & (COMBAT_MOVEMENT_LOS | COMBAT_MOVEMENT_DISTANCE | COMBAT_MOVEMENT_OOM | COMBAT_MOVEMENT_SILENCE))
                 {
-                    ClearCombatMovementFlags(COMBAT_MOVEMENT_LOS | COMBAT_MOVEMENT_DISTANCE | COMBAT_MOVEMENT_OOM);
+                    bool silenceOff = m_combatMovement & COMBAT_MOVEMENT_SILENCE;
+                    ClearCombatMovementFlags(COMBAT_MOVEMENT_LOS | COMBAT_MOVEMENT_DISTANCE | COMBAT_MOVEMENT_OOM | COMBAT_MOVEMENT_SILENCE);
 
-                    if (!IsCombatMovement() && m_creature->IsNonMeleeSpellCasted(false) && m_creature->IsInCombat() && m_creature->getVictim())
+                    if (m_creature->IsInCombat() && m_creature->getVictim() && 
+                        (silenceOff || (!IsCombatMovement() && m_creature->IsNonMeleeSpellCasted(false))))
                     {
-                        SetCombatMovement(false,true); 
+                        SetCombatMovement(true, true);      // resetting the same chase movegen
                         m_creature->SendMeleeAttackStop(m_creature->getVictim());
                     }
                 }

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -17954,6 +17954,7 @@ void Player::ContinueTaxiFlight()
 
 void Player::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
 {
+    Unit::ProhibitSpellSchool(idSchoolMask, unTimeMs);
     // last check 2.0.10
     WorldPacket data(SMSG_SPELL_COOLDOWN, 8 + 1 + m_spells.size() * 8);
     data << GetObjectGuid();

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -275,6 +275,11 @@ Unit::Unit() :
 
     m_isCreatureLinkingTrigger = false;
     m_isSpawningLinked = false;
+
+    // disabled spell school
+    uint32 rightnow = WorldTimer::getMSTime() - 1;
+    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
+        m_schoolAllowedSince[i] = rightnow;
 }
 
 Unit::~Unit()
@@ -9959,4 +9964,28 @@ void Unit::DisableSpline()
 {
     m_movementInfo.RemoveMovementFlag(MovementFlags(MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_FORWARD));
     movespline->_Interrupt();
+}
+
+bool Unit::IsSchoolAllowed(SpellSchoolMask mask) const
+{
+    uint32 now = WorldTimer::getMSTime();
+    uint32 imask = mask;
+    while (int i = ffs(imask))
+    {
+        if (m_schoolAllowedSince[i - 1] > now)
+            return false;
+        imask &= ~(1 << (i - 1));
+    }
+    return true;
+}
+
+void Unit::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
+{
+    uint32 when = WorldTimer::getMSTime() + unTimeMs;
+    uint32 imask = idSchoolMask;
+    while (int i = ffs(imask))
+    {
+        m_schoolAllowedSince[i - 1] = when;
+        imask &= ~(1 << (i - 1));
+    }
 }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -9969,23 +9969,21 @@ void Unit::DisableSpline()
 bool Unit::IsSchoolAllowed(SpellSchoolMask mask) const
 {
     uint32 now = WorldTimer::getMSTime();
-    uint32 imask = mask;
-    while (int i = ffs(imask))
+    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
     {
-        if (m_schoolAllowedSince[i - 1] > now)
-            return false;
-        imask &= ~(1 << (i - 1));
+        if (mask & (1 << i))
+            if (m_schoolAllowedSince[i] > now)
+                return false;
     }
     return true;
 }
 
-void Unit::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
+void Unit::ProhibitSpellSchool(SpellSchoolMask mask, uint32 unTimeMs)
 {
     uint32 when = WorldTimer::getMSTime() + unTimeMs;
-    uint32 imask = idSchoolMask;
-    while (int i = ffs(imask))
+    for (int i = 0; i < MAX_SPELL_SCHOOL; ++i)
     {
-        m_schoolAllowedSince[i - 1] = when;
-        imask &= ~(1 << (i - 1));
+        if (mask & (1 << i))
+            m_schoolAllowedSince[i] = when;
     }
 }

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -3462,7 +3462,8 @@ class Unit : public WorldObject
         float GetCreateStat(Stats stat) const { return m_createStats[stat]; }
 
         void SetCurrentCastedSpell(Spell* pSpell);
-        virtual void ProhibitSpellSchool(SpellSchoolMask /*idSchoolMask*/, uint32 /*unTimeMs*/) { }
+        bool IsSchoolAllowed(SpellSchoolMask mask) const;
+        virtual void ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs);
         void InterruptSpell(CurrentSpellTypes spellType, bool withDelayed = true);
         void FinishSpell(CurrentSpellTypes spellType, bool ok = true);
 
@@ -3820,6 +3821,7 @@ class Unit : public WorldObject
 
         MotionMaster i_motionMaster;
 
+        uint32 m_schoolAllowedSince[MAX_SPELL_SCHOOL];
         uint32 m_reactiveTimer[MAX_REACTIVE];
         uint32 m_regenTimer;
         uint32 m_lastManaUseTimer;

--- a/src/game/Object/UpdateFields.h
+++ b/src/game/Object/UpdateFields.h
@@ -459,4 +459,18 @@ enum ECorpseFields
     CORPSE_FIELD_PAD                          = OBJECT_END + 0x0021, // Size: 1, Type: INT, Flags: NONE
     CORPSE_END                                = OBJECT_END + 0x0022,
 };
+
+// Returns one plus the index of the least significant 1-bit of x, or if x is zero, returns zero
+static inline uint32 ffs(const uint32 x)
+{
+#ifdef WIN32
+    unsigned long r = 0;
+    if (_BitScanForward(&r, x))
+        return uint32(r + 1);
+    return 0;
+#elif
+    return __builtin_ffs(x);
+#endif
+}
+
 #endif

--- a/src/game/Object/UpdateFields.h
+++ b/src/game/Object/UpdateFields.h
@@ -461,16 +461,16 @@ enum ECorpseFields
 };
 
 // Returns one plus the index of the least significant 1-bit of x, or if x is zero, returns zero
-static inline uint32 ffs(const uint32 x)
-{
-#ifdef WIN32
-    unsigned long r = 0;
-    if (_BitScanForward(&r, x))
-        return uint32(r + 1);
-    return 0;
-#elif
-    return __builtin_ffs(x);
-#endif
-}
+//static inline uint32 ffs(const uint32 x)
+//{
+//#ifdef WIN32
+//    unsigned long r = 0;
+//    if (_BitScanForward(&r, x))
+//        return uint32(r + 1);
+//    return 0;
+//#elif
+//    return __builtin_ffs(x);
+//#endif
+//}
 
 #endif

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4201,6 +4201,9 @@ SpellCastResult Spell::CheckCast(bool strict)
     // check global cooldown
     if (strict && !m_IsTriggeredSpell && HasGlobalCooldown())
         { return SPELL_FAILED_NOT_READY; }
+    // check disabled spell school; TODO how to handle triggered spells?
+    if (strict && GetSpellSchoolMask(m_spellInfo) && !m_caster->IsSchoolAllowed(GetSpellSchoolMask(m_spellInfo)))
+        return SPELL_FAILED_SILENCED;
 
     // only allow triggered spells if at an ended battleground
     if (!m_IsTriggeredSpell && m_caster->GetTypeId() == TYPEID_PLAYER)

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -4857,6 +4857,14 @@ void Spell::EffectInterruptCast(SpellEffectIndex /*eff_idx*/)
             {
                 unitTarget->ProhibitSpellSchool(GetSpellSchoolMask(curSpellInfo), GetSpellDuration(m_spellInfo));
                 unitTarget->InterruptSpell(CurrentSpellTypes(i), false);
+                if (unitTarget->ToCreature())
+                {
+                    if (CreatureAI* ai = unitTarget->ToCreature()->AI())    // TODO setup a better way to inform AI
+                    {
+                        ai->SetCombatMovement(true, true);
+                        ai->AddCombatMovementFlags(COMBAT_MOVEMENT_SILENCE);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
**Please keep these commits separate.**
1. There are many places where 1-bit searching in a mask is done. For this, (at least) Intel x86 architecture has [the special CPU instruction](http://www.felixcloutier.com/x86/BSF.html). The wrappers are supported by (at least) Microsoft C and GNU C. The function is intended to simplify the following cycle constructs:
`for(int i=0; i<32; ++i) { if (mask & (1 << i) DO_SOMETHING(i-th bit set); } `
The actual efficiency gain must be proven by profilers; the largest one will be in case of sparse 1-bits within a 32-bit mask, though for a full 1-mask an efficiency may be even lost. A rough estimate gives 32 additions, shifts and tests (bit and) for the full cycle above and a bit search, addition, subtraction, shift, bit neg, and test **per 1-bit** for the following cycle:
`while (int i = ffs(mask)) { DO_SOMETHING((i-1)th bit set); clear (i-1)th mask bit; }`
Thus, the optimistic estimation (Pentium CPUs since Nehalem microarchitecture) gives performance gain for half- and lower filled 32-bit masks, with up to about 16 set bits. On AMD CPUs it may be quite worse.
The need of this is disputable, though UpdateMasks are very long and look usually sparse. Anyway, this is about bleeding-edge performance on the latest hardware.
2. The "prohibit spell school for X seconds" effect must be efficient for mobs as well as for players. For players, we cannot rely on client-side cast disabling because of possible cheating.
3. A mob-caster under "prohibit spell school" effect starts the chasing motion instantly intending melee. Needs check for the case of different school spells by a caster. Also, `SetCombatMovement(*, false)` has no effect, thus the default 2nd parameter value is set to true.
4. After some thoughts, I decided to drop the optimization done in 1. The open source code must be transferable and reliable, with that may be also slow and stupid :) A more proper way seems keeping the possible changes commented out. Also, for particular spell school mask it barely matters due to the small mask length (7 bits only). As a bonus, this change makes the build checking systems happy.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/74)
<!-- Reviewable:end -->
