### PR TITLE
Fix the crash introduced in #a5a6bf2

### DIFF
--- a/src/game/WorldHandlers/TaxiHandler.cpp
+++ b/src/game/WorldHandlers/TaxiHandler.cpp
@@ -205,15 +205,15 @@ void WorldSession::HandleMoveSplineDoneOpcode(WorldPacket& recv_data)
     recv_data >> movementInfo;
     recv_data >> Unused<uint32>();                          // unk
 
-
     // a unit (player) path, like transport one, may contain arrive/departure events; signal the last node arrive here
     // TODO find a way to send event for any path node? TODO is there a better way to get the last TaxiPathNodeEntry?
-    uint32 pathid = GetPlayer()->m_taxi.GetCurrentTaxiPath();
-    TaxiPathNodeList const& nlist = sTaxiPathNodesByPath[pathid];
-    if (uint32 eventid = nlist[nlist.size() - 1].arrivalEventID)
-        if (!sScriptMgr.OnProcessEvent(eventid, GetPlayer(), GetPlayer(), false))
-            GetPlayer()->GetMap()->ScriptsStart(DBS_ON_EVENT, eventid, GetPlayer(), GetPlayer());
-
+    if (uint32 pathid = GetPlayer()->m_taxi.GetCurrentTaxiPath())
+    {
+        TaxiPathNodeList const& nlist = sTaxiPathNodesByPath[pathid];
+        if (uint32 eventid = nlist[nlist.size() - 1].arrivalEventID)
+            if (!sScriptMgr.OnProcessEvent(eventid, GetPlayer(), GetPlayer(), false))
+                GetPlayer()->GetMap()->ScriptsStart(DBS_ON_EVENT, eventid, GetPlayer(), GetPlayer());
+    }
 
     // in taxi flight packet received in 2 case:
     // 1) end taxi path in far (multi-node) flight


### PR DESCRIPTION
The server gets a CMSG_MOVE_SPLINE_DONE packet when a server-controlled player movement is finished, including random walking under polymorph, charge and so on. At that, there is no taxi path (pathId is 0 in the packet) and any path usage must be avoided.

Thanks to Fresh (getMangos) for the feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/75)
<!-- Reviewable:end -->
