### PR TITLE
Fix Warlock Drain Soul mechanic while in a party

### DIFF
--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -3206,7 +3206,7 @@ void Aura::HandleChannelDeathItem(bool apply, bool Real)
         {
             // Only from non-grey units
             if (!((Player*)caster)->isHonorOrXPTarget(victim) ||
-                (victim->GetTypeId() == TYPEID_UNIT && !((Player*)caster)->isAllowedToLoot((Creature*)victim)))
+                (victim->GetTypeId() == TYPEID_UNIT && !((Creature*)victim)->IsTappedBy((Player*)caster)))
                 { return; }
         }
 


### PR DESCRIPTION
  - Warlocks were unable to get Soul Shards while in a group
  - References https://www.getmangos.eu/forums/topic/10389-is-drain-soul-broken/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/78)
<!-- Reviewable:end -->
