### PR TITLE
Fix crash at startUp due to command localization loading

### DIFF
--- a/src/game/WorldHandlers/CommandMgr.cpp
+++ b/src/game/WorldHandlers/CommandMgr.cpp
@@ -70,7 +70,7 @@ void CommandMgr::LoadCommandHelpLocale()
         uint32 commandId = fields[0].GetUInt32(); // to assign with db data
 
         CommandHelpLocale& data = m_CommandHelpLocaleMap[commandId];
-        for (int i = 1; i <= MAX_LOCALE; ++i)
+        for (int i = 1; i < MAX_LOCALE; ++i)
         {
             std::string str = fields[i].GetCppString();
             if (!str.empty())


### PR DESCRIPTION
The crash was due to MAX_LOCALE = 9 in Mangos One compared to MAX_LOCALE = 8 in mangos Zero

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/91)
<!-- Reviewable:end -->
