### PR TITLE
movement server time calculation and zeroing fix

### DIFF
--- a/src/game/WorldHandlers/MovementHandler.cpp
+++ b/src/game/WorldHandlers/MovementHandler.cpp
@@ -35,6 +35,8 @@
 #include "MapPersistentStateMgr.h"
 #include "ObjectMgr.h"
 
+#define MOVEMENT_DELAY_MS 500
+
 #if defined(WIN32) && !defined(__MINGW32__)
 #include <mmsystem.h>
 #pragma comment(lib, "winmm.lib")
@@ -327,30 +329,15 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recv_data)
     /*----------------*/
 
     // Calculate timestamp
-    int32 move_time, mstime;
-    mstime = mTimeStamp();
+    const uint32 mstime = mTimeStamp();
     if (m_clientTimeDelay == 0)
     {
         m_clientTimeDelay = mstime - movementInfo.GetTime();
     }
 
-    /* if(movementInfo.GetTime() - (mstime + m_clientTimeDelay) < 0)
-    {
-        move_time = mstime + 500;
-        move_time -= (movementInfo.GetTime() - (mstime + m_clientTimeDelay));
-        movementInfo.UpdateTime(move_time);
-    }
-    else
-    {
-    int calc_var = (movementInfo.GetTime() - (mstime + m_clientTimeDelay));
-    if(calc_var < 0)
-    {
-        calc_var *= -1;
-    }
-    calc_var += 500 + mstime;
-    move_time = calc_var; */
+    uint32 delay = mstime + m_clientTimeDelay;
+    uint32 move_time = movementInfo.GetTime() - delay + mstime + MOVEMENT_DELAY_MS;
 
-    move_time = (movementInfo.GetTime() - (mstime - m_clientTimeDelay)) + 500 + mstime;
     movementInfo.UpdateTime(move_time);
 
     if (!VerifyMovementInfo(movementInfo))
@@ -651,7 +638,7 @@ bool WorldSession::VerifyMovementInfo(MovementInfo const& movementInfo) const
 
 void WorldSession::HandleMoverRelocation(MovementInfo& movementInfo)
 {
-    movementInfo.UpdateTime(WorldTimer::getMSTime());
+    //movementInfo.UpdateTime(WorldTimer::getMSTime());
 
     Unit* mover = _player->GetMover();
 


### PR DESCRIPTION
After `movementInfo.UpdateTime(move_time);` in `WorldSession::HandleMovementOpcodes` time in movementinfo was updated again in `WorldSession::HandleMoverRelocation` by `movementInfo.UpdateTime(WorldTimer::getMSTime());` which as I can see the reason  wired visible players movement stuttering because `WorldTimer::getMSTime()` not the same with mTimeStamp() and future calculations in `HandleMovementOpcodes()` procedure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/100)
<!-- Reviewable:end -->
