### PR TITLE
Update Player.cpp for Issue "All spells buyable from class trainer"

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4462,7 +4462,8 @@ TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell
 
     // check level requirement
     bool prof = SpellMgr::IsProfessionSpell(trainer_spell->spell);
-    if (prof || trainer_spell->reqLevel && (trainer_spell->reqLevel) < reqLevel)
+    // Get the player's level and compare it with the required level of the spell
+    if (prof || (trainer_spell->reqLevel && (getLevel() < trainer_spell->reqLevel)))
     {
         return TRAINER_SPELL_RED;
     }


### PR DESCRIPTION
"All spells buyable from class trainer"
The issue seems to stem from the conditions in the code not properly checking the player's level against the required level (reqLevel) of the spell at the trainers. The old code snippet as it stands checks if the spell is a profession spell and if the required level of the spell is less than reqLevel, but it doesn't compare it to the player's actual level, which it seems like it should. I added the check.

Tested by compiling the main repo using windows. I went to the hunter trainer Einris Brightspear. I was a level 12 hunter and purchased Explosive Traps rank 1.  The spell requires lv 34. I learned the spell at lv 12. Then, using git, in a new folder, I compiled from my updated repo. I used the same config files and same data files only changing out all the build install files to the updated ones. I then logged in and after unlearning the spell, I tried to purchase it again but could not because my level was not sufficient. I had plenty of gold. I then used .gm level up to level me up to 54 and purchased the spell and everything worked well. The spell worked fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/111)
<!-- Reviewable:end -->
