### PR TITLE
Add .npc watch diagnostic command (LivingWorld Phase 1)

### DIFF
--- a/src/game/ChatCommands/CreatureCommands.cpp
+++ b/src/game/ChatCommands/CreatureCommands.cpp
@@ -1203,6 +1203,73 @@ bool ChatHandler::HandleNpcChangeEntryCommand(char* args)
 }
 
 /**
+ * @brief Handler for the .npc watch command (LivingWorld diagnostic, Phase 1).
+ *
+ * Read-only, one-shot snapshot of the currently selected creature. Inspects already-loaded
+ * state only via in-memory getters; performs no grid load, no map creation, and no
+ * movement/combat/AI/grid-state mutation.
+ *
+ * @param args Unused.
+ * @returns True on success; false (with the select-creature error) when nothing is selected.
+ */
+bool ChatHandler::HandleNpcWatchCommand(char* /*args*/)
+{
+    Creature* target = getSelectedCreature();
+
+    if (!target)
+    {
+        SendSysMessage(LANG_SELECT_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    float x = target->GetPositionX();
+    float y = target->GetPositionY();
+    float z = target->GetPositionZ();
+    float o = target->GetOrientation();
+
+    GridPair gridPair = MaNGOS::ComputeGridPair(x, y);
+    CellPair cellPair = MaNGOS::ComputeCellPair(x, y);
+    bool gridLoaded = target->GetMap()->IsLoaded(x, y);     // read-only: does NOT load the grid
+
+    PSendSysMessage("[LivingWorld] watch %s \"%s\"",
+                    target->GetGuidStr().c_str(), target->GetName());
+    PSendSysMessage("  map=%u instance=%u", target->GetMapId(), target->GetInstanceId());
+    PSendSysMessage("  pos x=%.3f y=%.3f z=%.3f o=%.3f", x, y, z, o);
+    PSendSysMessage("  grid[%u,%u] cell[%u,%u] grid-loaded=%s",
+                    gridPair.x_coord, gridPair.y_coord, cellPair.x_coord, cellPair.y_coord,
+                    gridLoaded ? "yes" : "no");
+    PSendSysMessage("  in-world=%s active-object=%s",
+                    target->IsInWorld() ? "yes" : "no",
+                    target->IsActiveObject() ? "yes" : "no");
+    PSendSysMessage("  movement-generator-type=%u in-combat=%s combat-timer=%u",
+                    uint32(target->GetMotionMaster()->GetCurrentMovementGeneratorType()),
+                    target->IsInCombat() ? "yes" : "no",
+                    target->GetCombatTimer());
+
+    if (Unit* victim = target->getVictim())
+    {
+        PSendSysMessage("  victim=%s", victim->GetGuidStr().c_str());
+    }
+    else
+    {
+        SendSysMessage("  victim=none");
+    }
+
+    ObjectGuid const& watchTargetGuid = target->GetTargetGuid();
+    if (!watchTargetGuid.IsEmpty())
+    {
+        PSendSysMessage("  target=%s", watchTargetGuid.GetString().c_str());
+    }
+    else
+    {
+        SendSysMessage("  target=none");
+    }
+
+    return true;
+}
+
+/**
  * @brief Handler for HandleNpcInfoCommand command.
  *
  * @param args Command arguments.

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -466,6 +466,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "say",            SEC_MODERATOR,      false, &ChatHandler::HandleNpcSayCommand,              "", NULL },
         { "textemote",      SEC_MODERATOR,      false, &ChatHandler::HandleNpcTextEmoteCommand,        "", NULL },
         { "unfollow",       SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcUnFollowCommand,         "", NULL },
+        { "watch",          SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcWatchCommand,            "", NULL },
         { "whisper",        SEC_MODERATOR,      false, &ChatHandler::HandleNpcWhisperCommand,          "", NULL },
         { "yell",           SEC_MODERATOR,      false, &ChatHandler::HandleNpcYellCommand,             "", NULL },
         { "tame",           SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcTameCommand,             "", NULL },

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -405,6 +405,7 @@ class ChatHandler
         bool HandleNpcTameCommand(char* args);
         bool HandleNpcTextEmoteCommand(char* args);
         bool HandleNpcUnFollowCommand(char* args);
+        bool HandleNpcWatchCommand(char* args);
         bool HandleNpcWhisperCommand(char* args);
         bool HandleNpcYellCommand(char* args);
 


### PR DESCRIPTION
Read-only, one-shot GM snapshot of the selected creature: guid/entry/name, map/instance, position, grid/cell pair, grid-loaded, in-world, active-object, movement-generator type, in-combat, combat-timer, and victim/target guids.

In-game GM-only (SEC_GAMEMASTER, console/RA disabled), modelled on .npc info. No grid load, map creation, nearby traversal, timers, DB/config, or movement/combat/AI mutation. Ported from MaNGOS Zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/117)
<!-- Reviewable:end -->
