### PR TITLE
Add LivingWorld startup observability summary

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -55,8 +55,13 @@
 
 #include "ItemEnchantmentMgr.h"
 #include <limits>
+#include <set>
 
 INSTANTIATE_SINGLETON_1(ObjectMgr);
+
+// Temporary startup accumulator for LivingWorld observability (written during LoadActiveEntities(NULL) only)
+static ObjectMgr::LivingWorldStartupStats s_livingWorldStats;
+static bool s_livingWorldStartupPass = false;
 
 /**
  * @brief Normalizes a player name to the server's canonical casing.
@@ -9795,11 +9800,14 @@ void ObjectMgr::LoadVendorTemplates()
  *
  *  This function is currently WIP, hence parts exist only as draft.
  */
-void ObjectMgr::LoadActiveEntities(Map* _map)
+ObjectMgr::LivingWorldStartupStats ObjectMgr::LoadActiveEntities(Map* _map)
 {
     // Special case on startup - load continents
     if (!_map)
     {
+        s_livingWorldStats = ObjectMgr::LivingWorldStartupStats();
+        s_livingWorldStartupPass = true;
+
         uint32 continents[] = {0, 1, 369, 530};
         for (int i = 0; i < countof(continents); ++i)
         {
@@ -9819,16 +9827,60 @@ void ObjectMgr::LoadActiveEntities(Map* _map)
             }
         }
 
-        return;
+        s_livingWorldStartupPass = false;
+        return s_livingWorldStats;
+    }
+
+    bool collectLivingWorldStats = s_livingWorldStartupPass;
+    bool forceLoad = sWorld.isForceLoadMap(_map->GetId());
+
+    uint32 mapTransportCount = 0;
+    uint32 forceLoadRequests = 0;
+    uint32 uniqueGridCount = 0;
+    uint32 newlyLoaded = 0;
+    uint32 alreadyLoaded = 0;
+    uint32 activeCreatureGuids = 0;
+
+    std::set<std::pair<uint32, uint32> > uniqueGrids;
+
+    if (collectLivingWorldStats)
+    {
+        MapManager::TransportMap::const_iterator transportMapItr = sMapMgr.m_TransportsByMap.find(_map->GetId());
+        if (transportMapItr != sMapMgr.m_TransportsByMap.end())
+        {
+            mapTransportCount = uint32(transportMapItr->second.size());
+        }
+
+        std::pair<ActiveCreatureGuidsOnMap::const_iterator, ActiveCreatureGuidsOnMap::const_iterator> activeBounds = m_activeCreatures.equal_range(_map->GetId());
+        for (ActiveCreatureGuidsOnMap::const_iterator itr = activeBounds.first; itr != activeBounds.second; ++itr)
+        {
+            ++activeCreatureGuids;
+        }
     }
 
     // Load active objects for _map
-    if (sWorld.isForceLoadMap(_map->GetId()))
+    if (forceLoad)
     {
         for (CreatureDataMap::const_iterator itr = mCreatureDataMap.begin(); itr != mCreatureDataMap.end(); ++itr)
         {
             if (itr->second.mapid == _map->GetId())
             {
+                if (collectLivingWorldStats)
+                {
+                    ++forceLoadRequests;
+                    GridPair gridPair = MaNGOS::ComputeGridPair(itr->second.posX, itr->second.posY);
+                    uniqueGrids.insert(std::make_pair(gridPair.x_coord, gridPair.y_coord));
+
+                    if (_map->IsLoaded(itr->second.posX, itr->second.posY))
+                    {
+                        ++alreadyLoaded;
+                    }
+                    else
+                    {
+                        ++newlyLoaded;
+                    }
+                }
+
                 _map->ForceLoadGrid(itr->second.posX, itr->second.posY);
             }
         }
@@ -9840,10 +9892,52 @@ void ObjectMgr::LoadActiveEntities(Map* _map)
         {
             CreatureData const& data = mCreatureDataMap[itr->second];
             {
+                if (collectLivingWorldStats)
+                {
+                    ++forceLoadRequests;
+                    GridPair gridPair = MaNGOS::ComputeGridPair(data.posX, data.posY);
+                    uniqueGrids.insert(std::make_pair(gridPair.x_coord, gridPair.y_coord));
+
+                    if (_map->IsLoaded(data.posX, data.posY))
+                    {
+                        ++alreadyLoaded;
+                    }
+                    else
+                    {
+                        ++newlyLoaded;
+                    }
+                }
+
                 _map->ForceLoadGrid(data.posX, data.posY);
             }
         }
     }
+
+    if (collectLivingWorldStats)
+    {
+        uniqueGridCount = uint32(uniqueGrids.size());
+
+        s_livingWorldStats.totalUniqueGrids += uniqueGridCount;
+        s_livingWorldStats.totalNewlyLoaded += newlyLoaded;
+        s_livingWorldStats.totalMapTransports += mapTransportCount;
+        if (forceLoad)
+        {
+            ++s_livingWorldStats.forcedMaps;
+        }
+
+        if (forceLoad)
+        {
+            sLog.outString("[LivingWorld] map %u: force-load=ON, creature-rows=%u, ForceLoadGrid-requests=%u, unique-grids=%u, newly-loaded=%u (explicit-locks-set), already-loaded=%u, extra-active-creatures=%u, map-transports=%u",
+                           _map->GetId(), forceLoadRequests, forceLoadRequests, uniqueGridCount, newlyLoaded, alreadyLoaded, activeCreatureGuids, mapTransportCount);
+        }
+        else
+        {
+            sLog.outString("[LivingWorld] map %u: force-load=OFF, extra-active-creatures=%u, ForceLoadGrid-requests=%u, unique-grids=%u, newly-loaded=%u (explicit-locks-set), already-loaded=%u, map-transports=%u",
+                           _map->GetId(), activeCreatureGuids, forceLoadRequests, uniqueGridCount, newlyLoaded, alreadyLoaded, mapTransportCount);
+        }
+    }
+
+    return ObjectMgr::LivingWorldStartupStats();
 }
 
 /**

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -758,8 +758,16 @@ class ObjectMgr
             LoadTrainers("npc_trainer", false);
         }
 
+        struct LivingWorldStartupStats
+        {
+            uint32 forcedMaps = 0;
+            uint32 totalUniqueGrids = 0;
+            uint32 totalNewlyLoaded = 0;
+            uint32 totalMapTransports = 0;
+        };
+
         /// @param _map Map* of the map for which to load active entities. If NULL active entities on continents are loaded
-        void LoadActiveEntities(Map* _map);
+        LivingWorldStartupStats LoadActiveEntities(Map* _map);
 
         std::string GeneratePetName(uint32 entry);
         uint32 GetBaseXP(uint32 level) const;

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1589,7 +1589,11 @@ void World::SetInitialWorldSettings()
     sLog.outString();
 
     sLog.outString("Loading grids for active creatures or transports...");
-    sObjectMgr.LoadActiveEntities(NULL);
+    uint32 loadContinentsBegin = GameTime::GetGameTimeMS();
+    ObjectMgr::LivingWorldStartupStats lwStats = sObjectMgr.LoadActiveEntities(NULL);
+    uint32 loadContinentsMs = GetMSTimeDiffToNow(loadContinentsBegin);
+    sLog.outString("[LivingWorld] startup summary: maps-forced=%u, total-unique-grids=%u, total-newly-loaded=%u, total-map-transports=%u, LoadContinents=%u ms",
+                   lwStats.forcedMaps, lwStats.totalUniqueGrids, lwStats.totalNewlyLoaded, lwStats.totalMapTransports, loadContinentsMs);
     sLog.outString();
 
     // Delete all characters which have been deleted X days before


### PR DESCRIPTION
## Summary

Ports the bounded LivingWorld startup summary to MaNGOS One.

This reports why active grids are loaded during startup, including configured force-loaded maps, extra-active creature requests, unique grids, newly-loaded vs already-loaded grids, and map-indexed transports.

## M1 notes

M1 performs the startup active-entity pass through `ObjectMgr::LoadActiveEntities(NULL)` rather than the M0 `MapManager::LoadContinents()` path.

M1 startup maps are `0, 1, 369, 530`.

Transport counts are reported as `map-transports` / `total-map-transports`, based on `MapManager::m_TransportsByMap`.

## Scope

Observability only.

No behavior changes, DB changes, config changes, GM commands, lease/activity-manager work, NPC classification changes, `ForceLoadGrid` signature changes, GridStates logging, or per-grid/per-creature spam.

## Verification

- `git diff --check`: PASS
- Build `game`: PASS
- Build `mangosd`: PASS
- Smoke `LoadAllGridsOnMaps = ""`: bounded startup `[LivingWorld]` lines, no post-startup runtime lines
- Smoke `LoadAllGridsOnMaps = "0"`: force-load summary appears, `total-map-transports=15`, no post-startup runtime lines

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/118)
<!-- Reviewable:end -->
