### PR TITLE
Fix linear monster movement path serialization

### DIFF
--- a/src/game/movement/packet_builder.cpp
+++ b/src/game/movement/packet_builder.cpp
@@ -125,19 +125,21 @@ namespace Movement
      */
     void WriteLinearPath(const Spline<int32>& spline, ByteBuffer& data)
     {
-        Movement::SplineBase::ControlArray const& pathPoint = spline.getPoints(); // get ref of whole path points array
+        uint32 last_idx = spline.getPointCount() - 3;
+        const Vector3* real_path = &spline.getPoint(1);
 
-        uint32 pathSize = spline.last() - spline.first() - 1; // -1 as we send destination first and last index is destination
-        MANGOS_ASSERT(pathSize >= 0);                       // should never be less than 0
-
-        Vector3 destination = pathPoint[spline.last()];     // destination of this path should be send right after path size
-        data << pathSize;
-        data << destination;
-
-        for (uint32 i = spline.first(); i < spline.first() + pathSize; i++) // from first real index (this array contain also special data)
+        data << last_idx;
+        data << real_path[last_idx];
+        if (last_idx > 1)
         {
-            Vector3 offset = destination - pathPoint[i];    // we have to send offset relative to destination instead of directly path point.
-            data.appendPackXYZ(offset.x, offset.y, offset.z); // we have to pack x,y,z before send
+            Vector3 destination = (real_path[0] + real_path[last_idx]) / 2.f;
+            Vector3 offset;
+            // first and last points already appended
+            for (uint32 i = 1; i < last_idx; ++i)
+            {
+                offset = destination - real_path[i];
+                data.appendPackXYZ(offset.x, offset.y, offset.z);
+            }
         }
     }
 


### PR DESCRIPTION
Restore the MaNGOS One/TBC-compatible WriteLinearPath packing format.

The previous rewrite serialized the creature start point as an intermediate packed path point, causing clients to display waypoint patrol NPCs briefly backtracking and correcting at waypoint transitions.

Verified in-game on Thelsamar and Northshire patrol guards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/121)
<!-- Reviewable:end -->
