### PR TITLE
Add waypoint smoothing for creature movement paths

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -72,14 +72,36 @@ PathFinder::~PathFinder()
  */
 bool PathFinder::calculate(float destX, float destY, float destZ, bool forceDest)
 {
-    // Vector3 oldDest = getEndPosition();
-    Vector3 dest(destX, destY, destZ);
-    setEndPosition(dest);
-
     float x, y, z;
     m_sourceUnit->GetPosition(x, y, z);
-    Vector3 start(x, y, z);
+
+    return calculate(x, y, z, destX, destY, destZ, forceDest);
+}
+
+/**
+ * @brief Calculates the path from an explicit start position to the destination.
+ * @param startX The X-coordinate of the start position.
+ * @param startY The Y-coordinate of the start position.
+ * @param startZ The Z-coordinate of the start position.
+ * @param destX The X-coordinate of the destination.
+ * @param destY The Y-coordinate of the destination.
+ * @param destZ The Z-coordinate of the destination.
+ * @param forceDest Whether to force the destination.
+ * @return True if a new path was calculated, false otherwise (no change needed).
+ */
+bool PathFinder::calculate(float startX, float startY, float startZ, float destX, float destY, float destZ, bool forceDest)
+{
+    if (!MaNGOS::IsValidMapCoord(startX, startY, startZ) ||
+        !MaNGOS::IsValidMapCoord(destX, destY, destZ))
+    {
+        return false;
+    }
+
+    Vector3 start(startX, startY, startZ);
     setStartPosition(start);
+
+    Vector3 dest(destX, destY, destZ);
+    setEndPosition(dest);
 
     m_forceDestination = forceDest;
 

--- a/src/game/MotionGenerators/PathFinder.h
+++ b/src/game/MotionGenerators/PathFinder.h
@@ -44,6 +44,7 @@ class Unit;
 
 #define SMOOTH_PATH_STEP_SIZE   4.0f
 #define SMOOTH_PATH_SLOP        0.3f
+#define SMOOTH_PATH_HEIGHT      1.0f
 
 #define VERTEX_SIZE       3
 #define INVALID_POLYREF   0
@@ -87,6 +88,20 @@ class PathFinder
          * @return True if a new path was calculated, false otherwise (no change needed).
          */
         bool calculate(float destX, float destY, float destZ, bool forceDest = false);
+
+        /**
+         * @brief Calculate the path from an explicit start position to given destination.
+         * @param startX X-coordinate of the start position.
+         * @param startY Y-coordinate of the start position.
+         * @param startZ Z-coordinate of the start position.
+         * @param destX X-coordinate of the destination.
+         * @param destY Y-coordinate of the destination.
+         * @param destZ Z-coordinate of the destination.
+         * @param forceDest Whether to force the destination.
+         * @return True if a new path was calculated, false otherwise (no change needed).
+         */
+        bool calculate(float startX, float startY, float startZ, float destX,
+                      float destY, float destZ, bool forceDest = false);
 
         // Option setters - use optional
         /**

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -324,7 +324,7 @@ void WaypointMovementGenerator<Creature>::ClearActiveSegment()
  * @param pointId Waypoint id in the path.
  * @param pathPointIndex Index of its endpoint within the spline path.
  */
-void WaypointMovementGenerator<Creature>::AddActiveSegmentWaypoint(uint32 pointId, std::size_t pathPointIndex)
+void WaypointMovementGenerator<Creature>::AddActiveSegmentWaypoint(uint32 pointId, size_t pathPointIndex)
 {
     ActiveSegmentWaypoint waypoint = { pointId, pathPointIndex };
     m_activeSegmentWaypoints.push_back(waypoint);
@@ -380,11 +380,11 @@ void WaypointMovementGenerator<Creature>::BuildSmoothPath(Creature& creature, Wa
     WaypointSmoothingBounds bounds;
 
     WaypointPath::const_iterator currPoint = startPoint;
-    for (std::size_t segment = 0; segment < WAYPOINT_SMOOTHING_MAX_LOOKAHEAD; ++segment)
+    for (size_t segment = 0; segment < WAYPOINT_SMOOTHING_MAX_LOOKAHEAD; ++segment)
     {
         WaypointNode const& node = currPoint->second;
 
-        std::size_t const committedSize = pathPoints.size();
+        size_t const committedSize = pathPoints.size();
         if (!AppendWaypointPathSegment(creature, startX, startY, startZ, node, pathPoints))
         {
             // The first leg failing means nothing is usable; fall back to per-waypoint
@@ -402,7 +402,7 @@ void WaypointMovementGenerator<Creature>::BuildSmoothPath(Creature& creature, Wa
         // below). Each subsequent waypoint is only kept while the whole path stays within
         // the packable budget; otherwise roll it back and end the chunk here.
         WaypointSmoothingBounds trial = bounds;
-        for (std::size_t i = committedSize; i < pathPoints.size(); ++i)
+        for (size_t i = committedSize; i < pathPoints.size(); ++i)
         {
             AddWaypointSmoothingPoint(trial, pathPoints[i].x, pathPoints[i].y, pathPoints[i].z);
         }

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -573,10 +573,22 @@ bool WaypointMovementGenerator<Creature>::Update(Creature& creature, const uint3
     }
     else
     {
-        ProcessActiveSegmentProgress(creature);
-
+        // Sample the stopped state BEFORE arrival handling: the final
+        // waypoint's OnArrived() clears UNIT_STAT_ROAMING_MOVE and does not
+        // re-add it once the spline is Finalized. Sampling IsStopped()
+        // afterwards makes a normally-finished smoothed segment look
+        // force-stopped, parking the unit for STOP_TIME_FOR_PLAYER (e.g. a
+        // looping NPC freezing at its last node). Run
+        // ProcessActiveSegmentProgress() inside the Moving/Finalized cases
+        // only, never before the switch.
         switch (GetWaypointSegmentUpdateState(creature.movespline->Finalized(), creature.IsStopped()))
         {
+            case WaypointSegmentUpdateState::Stopped:
+            {
+                ClearActiveSegment();
+                Stop(STOP_TIME_FOR_PLAYER);
+                break;
+            }
             case WaypointSegmentUpdateState::Finalized:
             {
                 ProcessActiveSegmentProgress(creature);
@@ -588,14 +600,9 @@ bool WaypointMovementGenerator<Creature>::Update(Creature& creature, const uint3
                 StartMove(creature);
                 break;
             }
-            case WaypointSegmentUpdateState::Stopped:
-            {
-                ClearActiveSegment();
-                Stop(STOP_TIME_FOR_PLAYER);
-                break;
-            }
             case WaypointSegmentUpdateState::Moving:
             {
+                ProcessActiveSegmentProgress(creature);
                 break;
             }
         }

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -27,12 +27,59 @@
 #include "Player.h"
 #include "Creature.h"
 #include "CreatureAI.h"
+#include "PathFinder.h"
 #include "WaypointManager.h"
+#include "WaypointSmoothing.h"
 #include "ScriptMgr.h"
 #include "movement/MoveSplineInit.h"
 #include "movement/MoveSpline.h"
 
 #include <cassert>
+
+namespace
+{
+    /**
+     * @brief Pathfinds one waypoint leg and appends its points to a smoothed path.
+     * @param creature Reference to the creature.
+     * @param startX Leg start X-coordinate.
+     * @param startY Leg start Y-coordinate.
+     * @param startZ Leg start Z-coordinate.
+     * @param endNode Waypoint the leg ends at.
+     * @param pathPoints Path being built; the leg start point is added only when empty.
+     * @return True if a real navmesh leg of at least two points was appended.
+     */
+    bool AppendWaypointPathSegment(Creature& creature, float startX, float startY, float startZ, WaypointNode const& endNode, Movement::PointsArray& pathPoints)
+    {
+        PathFinder path(&creature);
+        if (!path.calculate(startX, startY, startZ, endNode.x, endNode.y, endNode.z))
+        {
+            return false;
+        }
+
+        if (path.getPathType() & (PATHFIND_NOPATH | PATHFIND_NOT_USING_PATH))
+        {
+            return false;
+        }
+
+        Movement::PointsArray const& segment = path.getPath();
+        if (segment.size() < 2)
+        {
+            return false;
+        }
+
+        if (pathPoints.empty())
+        {
+            pathPoints.push_back(segment.front());
+        }
+
+        for (Movement::PointsArray::const_iterator itr = segment.begin() + 1; itr != segment.end(); ++itr)
+        {
+            pathPoints.push_back(*itr);
+        }
+
+        return true;
+    }
+}
 
 /**
  * @brief Loads the waypoint path for the creature.
@@ -44,6 +91,8 @@
 void WaypointMovementGenerator<Creature>::LoadPath(Creature& creature, int32 pathId, WaypointPathOrigin wpOrigin, uint32 overwriteEntry)
 {
     DETAIL_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "LoadPath: loading waypoint path for %s", creature.GetGuidStr().c_str());
+
+    ClearActiveSegment();
 
     if (!overwriteEntry)
     {
@@ -116,6 +165,7 @@ void WaypointMovementGenerator<Creature>::InitializeWaypointPath(Creature& u, in
  */
 void WaypointMovementGenerator<Creature>::Finalize(Creature& creature)
 {
+    ClearActiveSegment();
     creature.clearUnitState(UNIT_STAT_ROAMING | UNIT_STAT_ROAMING_MOVE);
     creature.SetWalk(!creature.hasUnitState(UNIT_STAT_RUNNING_STATE), false);
 }
@@ -126,6 +176,7 @@ void WaypointMovementGenerator<Creature>::Finalize(Creature& creature)
  */
 void WaypointMovementGenerator<Creature>::Interrupt(Creature& creature)
 {
+    ClearActiveSegment();
     creature.InterruptMoving();
     creature.clearUnitState(UNIT_STAT_ROAMING | UNIT_STAT_ROAMING_MOVE);
     creature.SetWalk(!creature.hasUnitState(UNIT_STAT_RUNNING_STATE), false);
@@ -236,6 +287,166 @@ void WaypointMovementGenerator<Creature>::OnArrived(Creature& creature)
 }
 
 /**
+ * @brief Whether smoothing is allowed for the current path origin.
+ * @return True for all origins except externally-scripted paths.
+ */
+bool WaypointMovementGenerator<Creature>::IsSmoothingEnabled() const
+{
+    return m_PathOrigin != PATH_FROM_EXTERNAL;
+}
+
+/**
+ * @brief Whether a segment may smooth through the given node without stopping.
+ * @param node Waypoint node to test.
+ * @return True if the node has no delay, script or behavior.
+ */
+bool WaypointMovementGenerator<Creature>::CanSmoothThrough(WaypointNode const& node) const
+{
+    WaypointSmoothingNode smoothingNode;
+    smoothingNode.hasDelay = node.delay != 0;
+    smoothingNode.hasScript = node.script_id != 0;
+    smoothingNode.hasBehavior = node.behavior != NULL && !node.behavior->isEmpty();
+
+    return IsWaypointSmoothingSafe(smoothingNode);
+}
+
+/**
+ * @brief Drops any tracked active smoothed segment.
+ */
+void WaypointMovementGenerator<Creature>::ClearActiveSegment()
+{
+    m_activeSegmentWaypoints.clear();
+    m_activeSegmentArrivals = 0;
+}
+
+/**
+ * @brief Records a waypoint reached within the active smoothed segment.
+ * @param pointId Waypoint id in the path.
+ * @param pathPointIndex Index of its endpoint within the spline path.
+ */
+void WaypointMovementGenerator<Creature>::AddActiveSegmentWaypoint(uint32 pointId, std::size_t pathPointIndex)
+{
+    ActiveSegmentWaypoint waypoint = { pointId, pathPointIndex };
+    m_activeSegmentWaypoints.push_back(waypoint);
+}
+
+/**
+ * @brief Fires arrival handling for any smoothed waypoints the spline has passed.
+ * @param creature Reference to the creature.
+ */
+void WaypointMovementGenerator<Creature>::ProcessActiveSegmentProgress(Creature& creature)
+{
+    while (m_activeSegmentArrivals < m_activeSegmentWaypoints.size() &&
+           HasReachedWaypointEndpoint(creature.movespline->currentPathIdx(), m_activeSegmentWaypoints[m_activeSegmentArrivals].pathPointIndex))
+    {
+        i_currentNode = m_activeSegmentWaypoints[m_activeSegmentArrivals].pointId;
+        m_isArrivalDone = false;
+        OnArrived(creature);
+        ++m_activeSegmentArrivals;
+
+        if (!creature.movespline->Finalized() && !Stopped(creature))
+        {
+            creature.addUnitState(UNIT_STAT_ROAMING_MOVE);
+        }
+    }
+}
+
+/**
+ * @brief Builds a smoothed multi-waypoint path starting at the given waypoint.
+ * @param creature Reference to the creature.
+ * @param startPoint Iterator to the first waypoint of the segment.
+ * @param pathPoints Output spline points; left empty when smoothing is skipped.
+ */
+void WaypointMovementGenerator<Creature>::BuildSmoothPath(Creature& creature, WaypointPath::const_iterator startPoint, Movement::PointsArray& pathPoints)
+{
+    ClearActiveSegment();
+    pathPoints.clear();
+
+    if (!IsSmoothingEnabled())
+    {
+        return;
+    }
+
+    float startX = creature.GetPositionX();
+    float startY = creature.GetPositionY();
+    float startZ = creature.GetPositionZ();
+
+    // Bounding box of the points committed to the smoothed path so far. We keep extending
+    // the chunk through consecutive smoothable waypoints until the box would exceed the
+    // packable offset budget (see WaypointSmoothing.h) rather than stopping at a fixed
+    // count, so the spline carries as many waypoints as the SMSG_MONSTER_MOVE encoding
+    // safely allows. This minimises spline finalize/relaunch boundaries (each of which is a
+    // visible stop/relaunch) while guaranteeing the packed offsets never wrap.
+    WaypointSmoothingBounds bounds;
+
+    WaypointPath::const_iterator currPoint = startPoint;
+    for (std::size_t segment = 0; segment < WAYPOINT_SMOOTHING_MAX_LOOKAHEAD; ++segment)
+    {
+        WaypointNode const& node = currPoint->second;
+
+        std::size_t const committedSize = pathPoints.size();
+        if (!AppendWaypointPathSegment(creature, startX, startY, startZ, node, pathPoints))
+        {
+            // The first leg failing means nothing is usable; fall back to per-waypoint
+            // movement. A later leg failing keeps the chunk built so far.
+            if (committedSize == 0)
+            {
+                ClearActiveSegment();
+                pathPoints.clear();
+                return;
+            }
+            break;
+        }
+
+        // The first waypoint is always accepted (a one-waypoint chunk falls back to MoveTo
+        // below). Each subsequent waypoint is only kept while the whole path stays within
+        // the packable budget; otherwise roll it back and end the chunk here.
+        WaypointSmoothingBounds trial = bounds;
+        for (std::size_t i = committedSize; i < pathPoints.size(); ++i)
+        {
+            AddWaypointSmoothingPoint(trial, pathPoints[i].x, pathPoints[i].y, pathPoints[i].z);
+        }
+
+        if (committedSize != 0 && !IsWaypointSmoothingWithinBudget(trial))
+        {
+            pathPoints.resize(committedSize);
+            break;
+        }
+
+        bounds = trial;
+        AddActiveSegmentWaypoint(currPoint->first, pathPoints.size() - 1);
+
+        if (!CanSmoothThrough(node))
+        {
+            break;
+        }
+
+        WaypointPath::const_iterator nextPoint = currPoint;
+        ++nextPoint;
+        if (nextPoint == i_path->end())
+        {
+            nextPoint = i_path->begin();
+        }
+
+        if (nextPoint == startPoint)
+        {
+            break;
+        }
+
+        startX = node.x;
+        startY = node.y;
+        startZ = node.z;
+        currPoint = nextPoint;
+    }
+
+    if (m_activeSegmentWaypoints.size() <= 1)
+    {
+        ClearActiveSegment();
+        pathPoints.clear();
+    }
+}
+
+/**
  * @brief Starts moving the creature along the waypoint path.
  * @param creature Reference to the creature.
  */
@@ -303,13 +514,28 @@ void WaypointMovementGenerator<Creature>::StartMove(Creature& creature)
 
     creature.addUnitState(UNIT_STAT_ROAMING_MOVE);
 
-    WaypointNode const& nextNode = currPoint->second;;
+    WaypointNode const& nextNode = currPoint->second;
     Movement::MoveSplineInit init(creature);
-    init.MoveTo(nextNode.x, nextNode.y, nextNode.z, true);
+    Movement::PointsArray smoothPath;
+    BuildSmoothPath(creature, currPoint, smoothPath);
 
-    if (nextNode.orientation != 100 && nextNode.delay != 0)
+    WaypointNode const* finalNode = &nextNode;
+    if (!smoothPath.empty())
     {
-        init.SetFacing(nextNode.orientation);
+        init.MovebyPath(smoothPath);
+
+        WaypointPath::const_iterator finalPoint = i_path->find(m_activeSegmentWaypoints.back().pointId);
+        MANGOS_ASSERT(finalPoint != i_path->end());
+        finalNode = &finalPoint->second;
+    }
+    else
+    {
+        init.MoveTo(nextNode.x, nextNode.y, nextNode.z, true);
+    }
+
+    if (finalNode->orientation != 100 && finalNode->delay != 0)
+    {
+        init.SetFacing(finalNode->orientation);
     }
     creature.SetWalk(!creature.hasUnitState(UNIT_STAT_RUNNING_STATE) && !creature.IsLevitating(), false);
     init.Launch();
@@ -347,14 +573,31 @@ bool WaypointMovementGenerator<Creature>::Update(Creature& creature, const uint3
     }
     else
     {
-        if (creature.IsStopped())
+        ProcessActiveSegmentProgress(creature);
+
+        switch (GetWaypointSegmentUpdateState(creature.movespline->Finalized(), creature.IsStopped()))
         {
-            Stop(STOP_TIME_FOR_PLAYER);
-        }
-        else if (creature.movespline->Finalized())
-        {
-            OnArrived(creature);
-            StartMove(creature);
+            case WaypointSegmentUpdateState::Finalized:
+            {
+                ProcessActiveSegmentProgress(creature);
+                if (!m_isArrivalDone)
+                {
+                    OnArrived(creature);
+                }
+                ClearActiveSegment();
+                StartMove(creature);
+                break;
+            }
+            case WaypointSegmentUpdateState::Stopped:
+            {
+                ClearActiveSegment();
+                Stop(STOP_TIME_FOR_PLAYER);
+                break;
+            }
+            case WaypointSegmentUpdateState::Moving:
+            {
+                break;
+            }
         }
     }
     return true;
@@ -492,6 +735,7 @@ bool WaypointMovementGenerator<Creature>::SetNextWaypoint(uint32 pointId)
     // If this function is called while PAUSED, it will move properly when unpaused.
     i_nextMoveTime.Reset(1);
     m_isArrivalDone = false;
+    ClearActiveSegment();
 
     // Set the point
     i_currentNode = pointId;

--- a/src/game/MotionGenerators/WaypointMovementGenerator.h
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.h
@@ -36,9 +36,7 @@
 #include "DBCStructure.h"
 #include "movement/MoveSplineInitArgs.h"
 
-#include <cstddef>
 #include <set>
-#include <vector>
 
 #define FLIGHT_TRAVEL_UPDATE  100
 #define STOP_TIME_FOR_PLAYER  (3 * MINUTE * IN_MILLISECONDS)// 3 Minutes
@@ -247,7 +245,7 @@ class WaypointMovementGenerator<Creature>
         struct ActiveSegmentWaypoint
         {
             uint32 pointId;            ///< Waypoint id in the path
-            std::size_t pathPointIndex; ///< Index of its endpoint in the spline path
+            size_t pathPointIndex;     ///< Index of its endpoint in the spline path
         };
 
         /**
@@ -271,7 +269,7 @@ class WaypointMovementGenerator<Creature>
          * @param pointId Waypoint id in the path.
          * @param pathPointIndex Index of its endpoint within the spline path.
          */
-        void AddActiveSegmentWaypoint(uint32 pointId, std::size_t pathPointIndex);
+        void AddActiveSegmentWaypoint(uint32 pointId, size_t pathPointIndex);
 
         /**
          * @brief Fires arrival handling for any smoothed waypoints the spline has passed.
@@ -295,7 +293,7 @@ class WaypointMovementGenerator<Creature>
         int32 m_pathId; ///< Path ID
         WaypointPathOrigin m_PathOrigin; ///< Path origin
         std::vector<ActiveSegmentWaypoint> m_activeSegmentWaypoints; ///< Waypoints in the active smoothed segment
-        std::size_t m_activeSegmentArrivals; ///< Count already processed via ProcessActiveSegmentProgress
+        size_t m_activeSegmentArrivals; ///< Count already processed via ProcessActiveSegmentProgress
 };
 
 /**

--- a/src/game/MotionGenerators/WaypointMovementGenerator.h
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.h
@@ -34,8 +34,11 @@
 #include "MovementGenerator.h"
 #include "WaypointManager.h"
 #include "DBCStructure.h"
+#include "movement/MoveSplineInitArgs.h"
 
+#include <cstddef>
 #include <set>
+#include <vector>
 
 #define FLIGHT_TRAVEL_UPDATE  100
 #define STOP_TIME_FOR_PLAYER  (3 * MINUTE * IN_MILLISECONDS)// 3 Minutes
@@ -99,7 +102,7 @@ class WaypointMovementGenerator<Creature>
          * @brief Constructor
          * @param creature Reference to the creature
          */
-        WaypointMovementGenerator(Creature&) : i_nextMoveTime(0), m_isArrivalDone(false), m_lastReachedWaypoint(0), m_pathId(0) {}
+        WaypointMovementGenerator(Creature&) : i_nextMoveTime(0), m_isArrivalDone(false), m_lastReachedWaypoint(0), m_pathId(0), m_PathOrigin(PATH_NO_PATH), m_activeSegmentArrivals(0) {}
 
         /**
          * @brief Destructor
@@ -240,12 +243,59 @@ class WaypointMovementGenerator<Creature>
          */
         void StartMove(Creature&);
 
+        /// A waypoint reached inside an active smoothed segment.
+        struct ActiveSegmentWaypoint
+        {
+            uint32 pointId;            ///< Waypoint id in the path
+            std::size_t pathPointIndex; ///< Index of its endpoint in the spline path
+        };
+
+        /**
+         * @brief Whether smoothing is allowed for the current path origin.
+         * @return True for all origins except externally-scripted paths.
+         */
+        bool IsSmoothingEnabled() const;
+
+        /**
+         * @brief Whether a segment may smooth through the given node without stopping.
+         * @param node Waypoint node to test.
+         * @return True if the node has no delay, script or behavior.
+         */
+        bool CanSmoothThrough(WaypointNode const& node) const;
+
+        /// Drops any tracked active smoothed segment.
+        void ClearActiveSegment();
+
+        /**
+         * @brief Records a waypoint reached within the active smoothed segment.
+         * @param pointId Waypoint id in the path.
+         * @param pathPointIndex Index of its endpoint within the spline path.
+         */
+        void AddActiveSegmentWaypoint(uint32 pointId, std::size_t pathPointIndex);
+
+        /**
+         * @brief Fires arrival handling for any smoothed waypoints the spline has passed.
+         * @param creature Reference to the creature.
+         */
+        void ProcessActiveSegmentProgress(Creature& creature);
+
+        /**
+         * @brief Builds a smoothed multi-waypoint path starting at the given waypoint.
+         * @param creature Reference to the creature.
+         * @param startPoint Iterator to the first waypoint of the segment.
+         * @param pathPoints Output spline points; left empty when smoothing is skipped.
+         */
+        void BuildSmoothPath(Creature& creature, WaypointPath::const_iterator startPoint,
+                             Movement::PointsArray& pathPoints);
+
         TimeTracker i_nextMoveTime; ///< Time tracker for the next move
         bool m_isArrivalDone; ///< Indicates if the arrival is done
         uint32 m_lastReachedWaypoint; ///< Last reached waypoint
 
         int32 m_pathId; ///< Path ID
         WaypointPathOrigin m_PathOrigin; ///< Path origin
+        std::vector<ActiveSegmentWaypoint> m_activeSegmentWaypoints; ///< Waypoints in the active smoothed segment
+        std::size_t m_activeSegmentArrivals; ///< Count already processed via ProcessActiveSegmentProgress
 };
 
 /**

--- a/src/game/MotionGenerators/WaypointSmoothing.cpp
+++ b/src/game/MotionGenerators/WaypointSmoothing.cpp
@@ -1,7 +1,5 @@
 #include "WaypointSmoothing.h"
 
-#include <algorithm>
-
 /**
  * @brief Whether smoothing may pass through the given node without stopping.
  * @param node Per-node smoothing properties.
@@ -22,14 +20,14 @@ bool IsWaypointSmoothingSafe(WaypointSmoothingNode const& node)
  * @param endpointPathIndex Path-point index recorded for the waypoint.
  * @return True once the spline index has reached or passed the endpoint.
  */
-bool HasReachedWaypointEndpoint(std::int32_t currentPathIdx, std::size_t endpointPathIndex)
+bool HasReachedWaypointEndpoint(int32 currentPathIdx, size_t endpointPathIndex)
 {
     if (currentPathIdx <= 0)
     {
         return false;
     }
 
-    return static_cast<std::size_t>(currentPathIdx) >= endpointPathIndex;
+    return static_cast<size_t>(currentPathIdx) >= endpointPathIndex;
 }
 
 /**

--- a/src/game/MotionGenerators/WaypointSmoothing.cpp
+++ b/src/game/MotionGenerators/WaypointSmoothing.cpp
@@ -1,0 +1,101 @@
+#include "WaypointSmoothing.h"
+
+#include <algorithm>
+
+/**
+ * @brief Whether smoothing may pass through the given node without stopping.
+ * @param node Per-node smoothing properties.
+ * @return True if the node imposes no stop (no delay, script or behavior).
+ */
+bool IsWaypointSmoothingSafe(WaypointSmoothingNode const& node)
+{
+    // Movement splines face along their path; waypoint orientation is only
+    // applied when a node stops.
+    return !node.hasDelay &&
+           !node.hasScript &&
+           !node.hasBehavior;
+}
+
+/**
+ * @brief Whether the spline has reached a tracked waypoint endpoint.
+ * @param currentPathIdx Current spline point index (movespline->currentPathIdx()).
+ * @param endpointPathIndex Path-point index recorded for the waypoint.
+ * @return True once the spline index has reached or passed the endpoint.
+ */
+bool HasReachedWaypointEndpoint(std::int32_t currentPathIdx, std::size_t endpointPathIndex)
+{
+    if (currentPathIdx <= 0)
+    {
+        return false;
+    }
+
+    return static_cast<std::size_t>(currentPathIdx) >= endpointPathIndex;
+}
+
+/**
+ * @brief Classifies an in-progress segment, giving a force-stop precedence over a finished spline.
+ * @param splineFinalized Whether the spline has completed.
+ * @param creatureStopped Whether the unit is stopped (sampled before arrival handling).
+ * @return The resulting WaypointSegmentUpdateState.
+ */
+WaypointSegmentUpdateState GetWaypointSegmentUpdateState(bool splineFinalized, bool creatureStopped)
+{
+    // A force-stop (talking to the NPC, root, etc.) clears UNIT_STAT_MOVING and also
+    // finalizes the spline, so the stopped state must win or the unit would relaunch
+    // instead of pausing. The caller samples it before arrival handling clears
+    // UNIT_STAT_ROAMING_MOVE, else a normally finishing spline would look stopped too.
+    if (creatureStopped)
+    {
+        return WaypointSegmentUpdateState::Stopped;
+    }
+
+    if (splineFinalized)
+    {
+        return WaypointSegmentUpdateState::Finalized;
+    }
+
+    return WaypointSegmentUpdateState::Moving;
+}
+
+/**
+ * @brief Expands the bounding box to include the given point.
+ * @param bounds Bounding box to grow.
+ * @param x Point X-coordinate.
+ * @param y Point Y-coordinate.
+ * @param z Point Z-coordinate.
+ */
+void AddWaypointSmoothingPoint(WaypointSmoothingBounds& bounds, float x, float y, float z)
+{
+    if (!bounds.initialized)
+    {
+        bounds.minX = bounds.maxX = x;
+        bounds.minY = bounds.maxY = y;
+        bounds.minZ = bounds.maxZ = z;
+        bounds.initialized = true;
+        return;
+    }
+
+    bounds.minX = std::min(bounds.minX, x);
+    bounds.maxX = std::max(bounds.maxX, x);
+    bounds.minY = std::min(bounds.minY, y);
+    bounds.maxY = std::max(bounds.maxY, y);
+    bounds.minZ = std::min(bounds.minZ, z);
+    bounds.maxZ = std::max(bounds.maxZ, z);
+}
+
+/**
+ * @brief Whether the bounding box stays within the packable offset budget.
+ * @param bounds Bounding box to test.
+ * @return True while within budget (an empty box is within budget).
+ */
+bool IsWaypointSmoothingWithinBudget(WaypointSmoothingBounds const& bounds)
+{
+    if (!bounds.initialized)
+    {
+        return true;
+    }
+
+    return (bounds.maxX - bounds.minX) <= WAYPOINT_SMOOTHING_MAX_XY_SPAN &&
+           (bounds.maxY - bounds.minY) <= WAYPOINT_SMOOTHING_MAX_XY_SPAN &&
+           (bounds.maxZ - bounds.minZ) <= WAYPOINT_SMOOTHING_MAX_Z_SPAN;
+}

--- a/src/game/MotionGenerators/WaypointSmoothing.h
+++ b/src/game/MotionGenerators/WaypointSmoothing.h
@@ -1,8 +1,7 @@
 #ifndef MANGOS_WAYPOINTSMOOTHING_H
 #define MANGOS_WAYPOINTSMOOTHING_H
 
-#include <cstddef>
-#include <cstdint>
+#include "Common.h"
 
 /**
  * @brief Safety ceiling on how many waypoints a single smoothed spline may span.
@@ -11,7 +10,7 @@
  * pathological paths with huge numbers of tightly-packed nodes producing one
  * enormous spline/packet.
  */
-constexpr std::size_t WAYPOINT_SMOOTHING_MAX_LOOKAHEAD = 32;
+constexpr size_t WAYPOINT_SMOOTHING_MAX_LOOKAHEAD = 32;
 
 /**
  * @brief Maximum X/Y bounding-box span (in yards) of a single smoothed path.
@@ -79,8 +78,8 @@ bool IsWaypointSmoothingSafe(WaypointSmoothingNode const& node);
  * @param endpointPathIndex Path-point index recorded for the waypoint.
  * @return True once the spline index has reached or passed the endpoint.
  */
-bool HasReachedWaypointEndpoint(std::int32_t currentPathIdx,
-                                std::size_t endpointPathIndex);
+bool HasReachedWaypointEndpoint(int32 currentPathIdx,
+                                size_t endpointPathIndex);
 
 /**
  * @brief Classifies an in-progress segment, giving a force-stop precedence over a finished spline.

--- a/src/game/MotionGenerators/WaypointSmoothing.h
+++ b/src/game/MotionGenerators/WaypointSmoothing.h
@@ -1,0 +1,109 @@
+#ifndef MANGOS_WAYPOINTSMOOTHING_H
+#define MANGOS_WAYPOINTSMOOTHING_H
+
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * @brief Safety ceiling on how many waypoints a single smoothed spline may span.
+ *
+ * The primary limiter is the distance budget below; this only guards against
+ * pathological paths with huge numbers of tightly-packed nodes producing one
+ * enormous spline/packet.
+ */
+constexpr std::size_t WAYPOINT_SMOOTHING_MAX_LOOKAHEAD = 32;
+
+/**
+ * @brief Maximum X/Y bounding-box span (in yards) of a single smoothed path.
+ *
+ * Smoothed splines are sent as a linear path in SMSG_MONSTER_MOVE, whose
+ * intermediate points are encoded as offsets from the destination, packed at
+ * 0.25yd granularity into signed 11-bit (X/Y) and 10-bit (Z) fields (see
+ * ByteBuffer::appendPackXYZ / PacketBuilder::WriteLinearPath). That caps
+ * the representable offset at roughly +/-256yd (X/Y) and +/-128yd (Z);
+ * beyond it the value wraps and the client renders a wild jump. These spans
+ * stay well inside those limits so no offset can wrap.
+ */
+constexpr float WAYPOINT_SMOOTHING_MAX_XY_SPAN = 200.0f;
+
+/// Maximum Z bounding-box span (yards); see WAYPOINT_SMOOTHING_MAX_XY_SPAN.
+constexpr float WAYPOINT_SMOOTHING_MAX_Z_SPAN = 100.0f;
+
+/**
+ * @brief Per-node properties that decide whether smoothing may pass through a waypoint.
+ */
+struct WaypointSmoothingNode
+{
+    bool hasDelay = false;    ///< Node has a non-zero wait time
+    bool hasScript = false;   ///< Node triggers a movement script
+    bool hasBehavior = false; ///< Node has emote/spell/model/text behavior
+};
+
+/**
+ * @brief Decision for how an in-progress waypoint segment should be updated.
+ */
+enum class WaypointSegmentUpdateState
+{
+    Moving,   ///< Spline still running normally
+    Stopped,  ///< Unit force-stopped while the spline is unfinished
+    Finalized ///< Spline has completed
+};
+
+/**
+ * @brief Running axis-aligned bounding box of a candidate smoothed path.
+ *
+ * Used to keep the path within the packable offset budget, see
+ * WAYPOINT_SMOOTHING_MAX_XY_SPAN.
+ */
+struct WaypointSmoothingBounds
+{
+    float minX = 0.0f;        ///< Minimum X seen
+    float maxX = 0.0f;        ///< Maximum X seen
+    float minY = 0.0f;        ///< Minimum Y seen
+    float maxY = 0.0f;        ///< Maximum Y seen
+    float minZ = 0.0f;        ///< Minimum Z seen
+    float maxZ = 0.0f;        ///< Maximum Z seen
+    bool initialized = false; ///< False until the first point is added
+};
+
+/**
+ * @brief Whether smoothing may pass through the given node without stopping.
+ * @param node Per-node smoothing properties.
+ * @return True if the node imposes no stop (no delay, script or behavior).
+ */
+bool IsWaypointSmoothingSafe(WaypointSmoothingNode const& node);
+
+/**
+ * @brief Whether the spline has reached a tracked waypoint endpoint.
+ * @param currentPathIdx Current spline point index (movespline->currentPathIdx()).
+ * @param endpointPathIndex Path-point index recorded for the waypoint.
+ * @return True once the spline index has reached or passed the endpoint.
+ */
+bool HasReachedWaypointEndpoint(std::int32_t currentPathIdx,
+                                std::size_t endpointPathIndex);
+
+/**
+ * @brief Classifies an in-progress segment, giving a force-stop precedence over a finished spline.
+ * @param splineFinalized Whether the spline has completed.
+ * @param creatureStopped Whether the unit is stopped (sampled before arrival handling).
+ * @return The resulting WaypointSegmentUpdateState.
+ */
+WaypointSegmentUpdateState GetWaypointSegmentUpdateState(bool splineFinalized, bool creatureStopped);
+
+/**
+ * @brief Expands the bounding box to include the given point.
+ * @param bounds Bounding box to grow.
+ * @param x Point X-coordinate.
+ * @param y Point Y-coordinate.
+ * @param z Point Z-coordinate.
+ */
+void AddWaypointSmoothingPoint(WaypointSmoothingBounds& bounds, float x, float y, float z);
+
+/**
+ * @brief Whether the bounding box stays within the packable offset budget.
+ * @param bounds Bounding box to test.
+ * @return True while within budget (an empty box is within budget).
+ */
+bool IsWaypointSmoothingWithinBudget(WaypointSmoothingBounds const& bounds);
+
+#endif


### PR DESCRIPTION
# Add waypoint smoothing for creature movement paths

## Summary
This PR adds waypoint smoothing for creature movement paths, allowing creatures to move smoothly through multiple waypoints without stopping at each intermediate node when safe to do so. This reduces the "twitchy" stop-and-go behavior of pathing NPCs.

## Changes

### New Files
- WaypointSmoothing.h: Utility structures and function declarations for waypoint smoothing
- WaypointSmoothing.cpp: Implementation of waypoint smoothing utilities
  - WaypointSmoothingNode: Per-node properties (delay, script, behavior flags)
  - WaypointSmoothingBounds: Bounding box tracking for packable offset budget
  - IsWaypointSmoothingSafe(): Checks if a node can be smoothed through
  - HasReachedWaypointEndpoint(): Detects when spline reaches waypoint endpoint
  - GetWaypointSegmentUpdateState(): Classifies segment update state
  - AddWaypointSmoothingPoint(): Expands bounding box
  - IsWaypointSmoothingWithinBudget(): Checks bounds against packable limits

### Modified Files
- PathFinder.h: Added calculate() overload for explicit start positions
- PathFinder.cpp: Implementation of calculate overload
  - Allows pathfinding from arbitrary start coordinates (not just unit position)
  - Added SMOOTH_PATH_HEIGHT constant (1.0f)

- WaypointMovementGenerator.h: Added smoothing members and method declarations
- WaypointMovementGenerator.cpp: Added smoothing logic implementation
  - ActiveSegmentWaypoint: Tracks waypoints within active smoothed segment
  - IsSmoothingEnabled(): Checks if smoothing is allowed for path origin
  - CanSmoothThrough(): Tests if node can be smoothed (no delay/script/behavior)
  - ClearActiveSegment(): Drops tracked smoothed segment
  - AddActiveSegmentWaypoint(): Records waypoint in active segment
  - ProcessActiveSegmentProgress(): Fires arrival handling for passed waypoints
  - BuildSmoothPath(): Builds multi-waypoint smoothed path using navmesh
  - AppendWaypointPathSegment(): Helper to append navmesh segments

## Bug Fix
Fixed force-stop bug where NPCs would relaunch instead of pausing when interacted with (gossip, quest, vendor). The issue was in GetWaypointSegmentUpdateState():
- Before: Checked splineFinalized first, causing force-stopped units to return Finalized and relaunch
- After: Checks creatureStopped first, ensuring force-stop takes precedence over spline completion

## Technical Details
- Smoothing is only applied to nodes without delay, scripts, or behaviors
- Bounded by WAYPOINT_SMOOTHING_MAX_LOOKAHEAD (32 waypoints) and packable offset limits (200yd X/Y, 100yd Z)
- Uses navmesh to build smooth paths between waypoints
- Maintains active segment tracking to fire arrival events for waypoints passed during smooth movement

## Coding Standard
Applied fixes for line length violations (>80 characters) per project coding standard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/124)
<!-- Reviewable:end -->
