### PR TITLE
Resume waypoint patrols from departure point after combat

### DIFF
--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -645,12 +645,54 @@ bool WaypointMovementGenerator<Creature>::CanMove(int32 diff, Creature& u)
  * @param o Reference to the orientation.
  * @return True if the reset position was successfully obtained, false otherwise.
  */
-bool WaypointMovementGenerator<Creature>::GetResetPosition(Creature&, float& x, float& y, float& z, float& o) const
+bool WaypointMovementGenerator<Creature>::GetResetPosition(Creature& creature, float& x, float& y, float& z, float& o) const
 {
     // Prevent a crash at empty waypoint path.
     if (!i_path || i_path->empty())
     {
         return false;
+    }
+
+    // Prefer resuming from the point where combat pulled the creature off
+    // its path (its departure point) rather than the last reached waypoint.
+    // This removes the visible backtrack where an evading patroller runs
+    // back to the previous waypoint and then re-walks the leg it was on.
+    // m_combatStartX/Y/Z is captured for every creature at the start of a new
+    // battle (Unit::Attack), so a creature that fought and is now evading
+    // holds the on-path position it had when it engaged. A zero sentinel
+    // means no combat start was recorded; in that case fall back below.
+    float combatX, combatY, combatZ;
+    creature.GetCombatStartPosition(combatX, combatY, combatZ);
+    if (combatX != 0.0f || combatY != 0.0f || combatZ != 0.0f)
+    {
+        x = combatX;
+        y = combatY;
+        z = combatZ;
+
+        // Face toward the waypoint the creature was heading for, so it keeps
+        // moving forward on resume; fall back to current facing if that point
+        // is unavailable or coincident.
+        WaypointPath::const_iterator nextPoint = i_path->find(i_currentNode);
+        if (nextPoint != i_path->end())
+        {
+            float dx = nextPoint->second.x - x;
+            float dy = nextPoint->second.y - y;
+            if (dx != 0.0f || dy != 0.0f)
+            {
+                o = atan2(dy, dx);
+                o = (o >= 0) ? o : 2 * M_PI_F + o;
+            }
+            else
+            {
+                o = creature.GetOrientation();
+            }
+        }
+        else
+        {
+            o = creature.GetOrientation();
+        }
+
+        return true;
     }
 
     WaypointPath::const_iterator lastPoint = i_path->find(m_lastReachedWaypoint);

--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -215,6 +215,13 @@ Creature::Creature(CreatureSubtype subtype) : Unit(),
     m_regenTimer = 200;
     m_valuesCount = UNIT_END;
 
+    // Zero sentinel: lets waypoint evade tell "combat start never recorded"
+    // apart from a real recorded position (set in Unit::Attack), so it can
+    // resume from the departure point instead of the last reached waypoint.
+    m_combatStartX = 0.0f;
+    m_combatStartY = 0.0f;
+    m_combatStartZ = 0.0f;
+
     for (int i = 0; i < CREATURE_MAX_SPELLS; ++i)
     {
         m_spells[i] = 0;


### PR DESCRIPTION
A waypoint creature pulled into combat between two waypoints used to evade back to its last reached waypoint and then re-walk the leg it was already on, producing a visible backtrack/rubber-band.

WaypointMovementGenerator::GetResetPosition now returns the creature's combat-start position (the on-path point it held when it engaged, already captured for every creature in Unit::Attack) and faces toward the waypoint it was heading for, so on evade it continues forward instead of running back. It falls back to the previous last-reached-waypoint behaviour when no combat-start position was recorded.

m_combatStartX/Y/Z are zero-initialised in the Creature constructor so the "never recorded" case is reliably distinguishable from a real position.

Scope is limited to DB waypoint patrollers: escort NPCs (PointMovement with their own combat-start resume), bosses/idle creatures (reset to spawn) and random wanderers are unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/126)
<!-- Reviewable:end -->
