### PR TITLE
[Decomp][Player] Extract HonorMgr/PetMgr/SpellCooldownMgr from Player.cpp

### DIFF
--- a/src/game/Object/HonorMgr.cpp
+++ b/src/game/Object/HonorMgr.cpp
@@ -1,0 +1,213 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "HonorMgr.h"
+#include "Player.h"
+#include "Creature.h"
+#include "WorldSession.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "Opcodes.h"
+#include "ObjectGuid.h"
+#include "UpdateFields.h"
+#include "Formulas.h"
+
+void HonorMgr::UpdateKills()
+{
+    /// called when rewarding honor and at each save
+    time_t now = time(NULL);
+    time_t today = (time(NULL) / DAY) * DAY;
+
+    if (m_lastUpdateTime < today)
+    {
+        time_t yesterday = today - DAY;
+
+        uint16 kills_today = PAIR32_LOPART(m_owner->GetUInt32Value(PLAYER_FIELD_KILLS));
+
+        // update yesterday's contribution
+        if (m_lastUpdateTime >= yesterday)
+        {
+            m_owner->SetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION, m_owner->GetUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION));
+
+            // this is the first update today, reset today's contribution
+            m_owner->SetUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, 0);
+            m_owner->SetUInt32Value(PLAYER_FIELD_KILLS, MAKE_PAIR32(0, kills_today));
+        }
+        else
+        {
+            // no honor/kills yesterday or today, reset
+            m_owner->SetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION, 0);
+            m_owner->SetUInt32Value(PLAYER_FIELD_KILLS, 0);
+        }
+    }
+
+    m_lastUpdateTime = now;
+}
+
+bool HonorMgr::Reward(Unit* uVictim, uint32 groupsize, float honor)
+{
+    // do not reward honor in arenas, but enable onkill spellproc
+    if (m_owner->InArena())
+    {
+        if (!uVictim || uVictim == m_owner || uVictim->GetTypeId() != TYPEID_PLAYER)
+        {
+            return false;
+        }
+
+        if (m_owner->GetBGTeam() == ((Player*)uVictim)->GetBGTeam())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    // 'Inactive' this aura prevents the player from gaining honor points and battleground tokens
+    if (m_owner->GetDummyAura(SPELL_AURA_PLAYER_INACTIVE))
+    {
+        return false;
+    }
+
+    ObjectGuid victim_guid;
+    uint32 victim_rank = 0;
+
+    // need call before fields update to have chance move yesterday data to appropriate fields before today data change.
+    UpdateKills();
+
+    if (honor <= 0)
+    {
+        if (!uVictim || uVictim == m_owner || uVictim->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
+        {
+            return false;
+        }
+
+        victim_guid = uVictim->GetObjectGuid();
+
+        if (uVictim->GetTypeId() == TYPEID_PLAYER)
+        {
+            Player* pVictim = (Player*)uVictim;
+
+            if (m_owner->GetTeam() == pVictim->GetTeam() && !sWorld.IsFFAPvPRealm())
+            {
+                return false;
+            }
+
+            float f = 1;                                    // need for total kills (?? need more info)
+            uint32 k_grey = 0;
+            uint32 k_level = m_owner->getLevel();
+            uint32 v_level = pVictim->getLevel();
+
+            {
+                // PLAYER_CHOSEN_TITLE VALUES DESCRIPTION
+                //  [0]      Just name
+                //  [1..14]  Alliance honor titles and player name
+                //  [15..28] Horde honor titles and player name
+                //  [29..38] Other title and player name
+                //  [39+]    Nothing
+                uint32 victim_title = pVictim->GetUInt32Value(PLAYER_CHOSEN_TITLE);
+                // Get Killer titles, CharTitlesEntry::bit_index
+                // Ranks:
+                //  title[1..14]  -> rank[5..18]
+                //  title[15..28] -> rank[5..18]
+                //  title[other]  -> 0
+                if (victim_title == 0)
+                {
+                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
+                }
+                else if (victim_title < 15)
+                {
+                    victim_rank = victim_title + 4;
+                }
+                else if (victim_title < 29)
+                {
+                    victim_rank = victim_title - 14 + 4;
+                }
+                else
+                {
+                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
+                }
+            }
+
+            k_grey = MaNGOS::XP::GetGrayLevel(k_level);
+
+            if (v_level <= k_grey)
+            {
+                return false;
+            }
+
+            float diff_level = (k_level == k_grey) ? 1 : ((float(v_level) - float(k_grey)) / (float(k_level) - float(k_grey)));
+
+            int32 v_rank = 1;                               // need more info
+
+            honor = ((f * diff_level * (190 + v_rank * 10)) / 6);
+            honor *= float(k_level) / 70.0f;                // factor of dependence on levels of the killer
+
+            // count the number of playerkills in one day
+            m_owner->ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
+            // and those in a lifetime
+            m_owner->ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
+        }
+        else
+        {
+            Creature* cVictim = (Creature*)uVictim;
+
+            if (!cVictim->IsRacialLeader())
+            {
+                return false;
+            }
+
+            honor = 100;                                    // ??? need more info
+            victim_rank = 19;                               // HK: Leader
+        }
+    }
+
+    if (uVictim != NULL)
+    {
+        honor *= sWorld.getConfig(CONFIG_FLOAT_RATE_HONOR);
+
+        if (groupsize > 1)
+        {
+            honor /= groupsize;
+        }
+
+        honor *= (((float)urand(8, 12)) / 10);              // approx honor: 80% - 120% of real honor
+    }
+
+    // honor - for show honor points in log
+    // victim_guid - for show victim name in log
+    // victim_rank [1..4]  HK: <dishonored rank>
+    // victim_rank [5..19] HK: <alliance\horde rank>
+    // victim_rank [0,20+] HK: <>
+    WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
+    data << uint32(honor);
+    data << ObjectGuid(victim_guid);
+    data << uint32(victim_rank);
+    m_owner->GetSession()->SendPacket(&data);
+
+    // add honor points
+    m_owner->ModifyHonorPoints(int32(honor));
+
+    m_owner->ApplyModUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, uint32(honor), true);
+    return true;
+}

--- a/src/game/Object/HonorMgr.h
+++ b/src/game/Object/HonorMgr.h
@@ -1,0 +1,87 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_HONORMGR
+#define MANGOS_H_HONORMGR
+
+#include "Common.h"
+
+class Player;
+class Unit;
+
+/**
+ * @brief Owns a Player's honor-system bookkeeping and per-kill reward calc.
+ *
+ * Scope: today / yesterday kill-and-contribution rollover, and the
+ * calculation that converts a kill into honor points + an SMSG_PVP_CREDIT
+ * packet to the client.
+ *
+ * What stays on Player and is NOT in HonorMgr:
+ *  - isHonorOrXPTarget(): a victim-eligibility filter that gates BOTH honor
+ *    and XP rewards, so it does not belong in an honor-specific module.
+ *  - The honor-points balance (PLAYER_FIELD_HONOR_CURRENCY) and its
+ *    Get/Set/ModifyHonorPoints accessors — HonorMgr awards honor through
+ *    Player::ModifyHonorPoints but does not own the long-term balance.
+ *  - The kill-count entity fields (PLAYER_FIELD_KILLS,
+ *    PLAYER_FIELD_LIFETIME_HONORABLE_KILLS) — those live on Player's
+ *    update mask, mutated via Player methods called through m_owner.
+ */
+class HonorMgr
+{
+    public:
+        /**
+         * @brief Constructs a HonorMgr bound to its owning Player.
+         *
+         * @param owner The Player whose honor bookkeeping this manager owns.
+         */
+        explicit HonorMgr(Player* owner) : m_owner(owner), m_lastUpdateTime(time(NULL)) {}
+
+        /**
+         * @brief Rolls today's kills/contribution over to yesterday once a calendar day has passed.
+         */
+        void UpdateKills();
+
+        /**
+         * @brief Compute honor points for a kill and credit them to the player.
+         *
+         * @param uVictim   The killed unit (player or racial-leader creature). May be NULL.
+         * @param groupsize Number of group members to split the honor across; 1 means solo.
+         * @param honor     Explicit honor value to award; pass a non-positive value to have it computed.
+         * @return True if honor was awarded or arena on-kill procs should fire; false otherwise.
+         */
+        bool Reward(Unit* uVictim, uint32 groupsize, float honor);
+
+        /**
+         * @brief Reset the timestamp that the daily rollover compares against.
+         *
+         * @param t The new last-update timestamp (e.g. the saved logout time).
+         */
+        void SetLastKillUpdate(time_t t) { m_lastUpdateTime = t; }
+
+    private:
+        Player* m_owner;            ///< Non-owning pointer to the Player this manager belongs to.
+        time_t  m_lastUpdateTime;   ///< Timestamp the daily kill rollover compares against.
+};
+
+#endif // MANGOS_H_HONORMGR

--- a/src/game/Object/PetMgr.cpp
+++ b/src/game/Object/PetMgr.cpp
@@ -1,0 +1,98 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "PetMgr.h"
+#include "Player.h"
+#include "Pet.h"
+#include "WorldPacket.h"
+#include "Opcodes.h"
+#include "Log.h"
+
+void PetMgr::LoadStableSlotsFromField(uint32 raw)
+{
+    m_stableSlots = raw;
+    if (m_stableSlots > MAX_PET_STABLES)
+    {
+        sLog.outError("Player can have not more %u stable slots, but have in DB %u", MAX_PET_STABLES, uint32(m_stableSlots));
+        m_stableSlots = MAX_PET_STABLES;
+    }
+}
+
+void PetMgr::Remove(PetSaveMode mode)
+{
+    if (Pet* pet = m_owner->GetPet())
+    {
+        pet->Unsummon(mode, m_owner);
+    }
+}
+
+void PetMgr::RemoveActionBar()
+{
+    WorldPacket data(SMSG_PET_SPELLS, 8);
+    data << ObjectGuid();
+    m_owner->SendDirectMessage(&data);
+}
+
+void PetMgr::UnsummonTemporaryIfAny()
+{
+    Pet* pet = m_owner->GetPet();
+    if (!pet)
+    {
+        return;
+    }
+
+    if (!m_temporaryUnsummonedPetNumber && pet->isControlled() && !pet->isTemporarySummoned())
+    {
+        m_temporaryUnsummonedPetNumber = pet->GetCharmInfo()->GetPetNumber();
+    }
+
+    pet->Unsummon(PET_SAVE_AS_CURRENT, m_owner);
+}
+
+void PetMgr::ResummonTemporaryUnsummonedIfAny()
+{
+    if (!m_temporaryUnsummonedPetNumber)
+    {
+        return;
+    }
+
+    // not resummon in not appropriate state
+    if (m_owner->IsPetNeedBeTemporaryUnsummoned())
+    {
+        return;
+    }
+
+    if (m_owner->GetPetGuid())
+    {
+        return;
+    }
+
+    Pet* NewPet = new Pet;
+    if (!NewPet->LoadPetFromDB(m_owner, 0, m_temporaryUnsummonedPetNumber, true))
+    {
+        delete NewPet;
+    }
+
+    m_temporaryUnsummonedPetNumber = 0;
+}

--- a/src/game/Object/PetMgr.h
+++ b/src/game/Object/PetMgr.h
@@ -1,0 +1,96 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_PETMGR
+#define MANGOS_H_PETMGR
+
+#include "Common.h"
+#include "Pet.h"  // PetSaveMode enum + MAX_PET_STABLES constant
+
+class Player;
+
+/**
+ * PetMgr — owns a Player's pet-ownership metadata: the stable-slot
+ * count persisted with the character row and the temporary-unsummon
+ * tracking number used by transports / mounts to bring the same pet
+ * back after a short interruption.
+ *
+ * What this DOES NOT own:
+ *  - The Pet creature itself (a Creature subclass living in the world,
+ *    managed by Object/Pet.{cpp,h}). Its lifecycle, AI, spells, and
+ *    persistence to the `character_pet` table all stay in Pet.cpp.
+ *  - The pet stable opcode handlers (CMSG_STABLE_PET and friends in
+ *    WorldHandlers/NPCHandler.cpp). They keep reading/updating the slot
+ *    count through Player's public accessors, so the stable-purchase
+ *    economics (gold cost via StableSlotPricesStore, MAX_PET_STABLES
+ *    cap) are untouched.
+ */
+class PetMgr
+{
+    public:
+        explicit PetMgr(Player* owner)
+            : m_owner(owner), m_stableSlots(0), m_temporaryUnsummonedPetNumber(0)
+        {
+        }
+
+        /// Number of paid stable slots the character has unlocked.
+        /// Persisted to `characters`.stable_slots; clamped to
+        /// MAX_PET_STABLES on load.
+        uint32 GetStableSlots() const { return m_stableSlots; }
+        void SetStableSlots(uint32 slots) { m_stableSlots = slots; }
+
+        /// Called from Player::LoadFromDB with the raw column value.
+        /// Clamps to MAX_PET_STABLES and logs a server error on
+        /// out-of-range data so an operator can detect a tampered row.
+        void LoadStableSlotsFromField(uint32 raw);
+
+        /// Pet number that was active before a temporary unsummon (e.g.
+        /// transport zone-in). Zero means no pending resummon.
+        uint32 GetTemporaryUnsummonedPetNumber() const { return m_temporaryUnsummonedPetNumber; }
+        void SetTemporaryUnsummonedPetNumber(uint32 petnumber) { m_temporaryUnsummonedPetNumber = petnumber; }
+
+        /// If the owner currently has a controlled pet, asks it to
+        /// unsummon with the given mode (see PetSaveMode).
+        void Remove(PetSaveMode mode);
+
+        /// SMSG_PET_SPELLS with an empty guid — clears the pet action
+        /// bar UI on the client.
+        void RemoveActionBar();
+
+        /// Stash the current non-temporary pet's number so we can bring
+        /// it back later, then unsummon with PET_SAVE_AS_CURRENT.
+        void UnsummonTemporaryIfAny();
+
+        /// Counterpart to UnsummonTemporaryIfAny: if we stashed a pet
+        /// number and it's now appropriate to resummon, load it from DB.
+        /// Clears the stash either way.
+        void ResummonTemporaryUnsummonedIfAny();
+
+    private:
+        Player* m_owner;
+        uint32  m_stableSlots;
+        uint32  m_temporaryUnsummonedPetNumber;
+};
+
+#endif // MANGOS_H_PETMGR

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -379,7 +379,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_petMgr(this), m_spellCooldownMgr(this), m_mover(this), m_camera(this), m_reputationMgr(this)
+Player::Player(WorldSession* session): Unit(), m_petMgr(this), m_honorMgr(this), m_spellCooldownMgr(this), m_mover(this), m_camera(this), m_reputationMgr(this)
 {
 #ifdef ENABLE_PLAYERBOTS
     m_playerbotAI = 0;
@@ -579,7 +579,7 @@ Player::Player(WorldSession* session): Unit(), m_petMgr(this), m_spellCooldownMg
 
     // Honor System
     // Set last honor update time to current time
-    m_lastHonorUpdateTime = time(NULL);
+    // m_lastHonorUpdateTime (now m_honorMgr) initialized by m_honorMgr ctor
 
     // Player summoning
     // Initialize summon expire time to 0
@@ -3540,187 +3540,7 @@ void Player::UpdateArenaFields(void)
     /* arena calcs go here */
 }
 
-void Player::UpdateHonorFields()
-{
-    /// called when rewarding honor and at each save
-    time_t now = time(NULL);
-    time_t today = (time(NULL) / DAY) * DAY;
 
-    if (m_lastHonorUpdateTime < today)
-    {
-        time_t yesterday = today - DAY;
-
-        uint16 kills_today = PAIR32_LOPART(GetUInt32Value(PLAYER_FIELD_KILLS));
-
-        // update yesterday's contribution
-        if (m_lastHonorUpdateTime >= yesterday)
-        {
-            SetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION, GetUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION));
-
-            // this is the first update today, reset today's contribution
-            SetUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, 0);
-            SetUInt32Value(PLAYER_FIELD_KILLS, MAKE_PAIR32(0, kills_today));
-        }
-        else
-        {
-            // no honor/kills yesterday or today, reset
-            SetUInt32Value(PLAYER_FIELD_YESTERDAY_CONTRIBUTION, 0);
-            SetUInt32Value(PLAYER_FIELD_KILLS, 0);
-        }
-    }
-
-    m_lastHonorUpdateTime = now;
-}
-
-/// Calculate the amount of honor gained based on the victim
-/// and the size of the group for which the honor is divided
-/// An exact honor value can also be given (overriding the calcs)
-bool Player::RewardHonor(Unit* uVictim, uint32 groupsize, float honor)
-{
-    // do not reward honor in arenas, but enable onkill spellproc
-    if (InArena())
-    {
-        if (!uVictim || uVictim == this || uVictim->GetTypeId() != TYPEID_PLAYER)
-        {
-            return false;
-        }
-
-        if (GetBGTeam() == ((Player*)uVictim)->GetBGTeam())
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    // 'Inactive' this aura prevents the player from gaining honor points and battleground tokens
-    if (GetDummyAura(SPELL_AURA_PLAYER_INACTIVE))
-    {
-        return false;
-    }
-
-    ObjectGuid victim_guid;
-    uint32 victim_rank = 0;
-
-    // need call before fields update to have chance move yesterday data to appropriate fields before today data change.
-    UpdateHonorFields();
-
-    if (honor <= 0)
-    {
-        if (!uVictim || uVictim == this || uVictim->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
-        {
-            return false;
-        }
-
-        victim_guid = uVictim->GetObjectGuid();
-
-        if (uVictim->GetTypeId() == TYPEID_PLAYER)
-        {
-            Player* pVictim = (Player*)uVictim;
-
-            if (GetTeam() == pVictim->GetTeam() && !sWorld.IsFFAPvPRealm())
-            {
-                return false;
-            }
-
-            float f = 1;                                    // need for total kills (?? need more info)
-            uint32 k_grey = 0;
-            uint32 k_level = getLevel();
-            uint32 v_level = pVictim->getLevel();
-
-            {
-                // PLAYER_CHOSEN_TITLE VALUES DESCRIPTION
-                //  [0]      Just name
-                //  [1..14]  Alliance honor titles and player name
-                //  [15..28] Horde honor titles and player name
-                //  [29..38] Other title and player name
-                //  [39+]    Nothing
-                uint32 victim_title = pVictim->GetUInt32Value(PLAYER_CHOSEN_TITLE);
-                // Get Killer titles, CharTitlesEntry::bit_index
-                // Ranks:
-                //  title[1..14]  -> rank[5..18]
-                //  title[15..28] -> rank[5..18]
-                //  title[other]  -> 0
-                if (victim_title == 0)
-                {
-                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
-                }
-                else if (victim_title < 15)
-                {
-                    victim_rank = victim_title + 4;
-                }
-                else if (victim_title < 29)
-                {
-                    victim_rank = victim_title - 14 + 4;
-                }
-                else
-                {
-                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
-                }
-            }
-
-            k_grey = MaNGOS::XP::GetGrayLevel(k_level);
-
-            if (v_level <= k_grey)
-            {
-                return false;
-            }
-
-            float diff_level = (k_level == k_grey) ? 1 : ((float(v_level) - float(k_grey)) / (float(k_level) - float(k_grey)));
-
-            int32 v_rank = 1;                               // need more info
-
-            honor = ((f * diff_level * (190 + v_rank * 10)) / 6);
-            honor *= float(k_level) / 70.0f;                // factor of dependence on levels of the killer
-
-            // count the number of playerkills in one day
-            ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
-            // and those in a lifetime
-            ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
-        }
-        else
-        {
-            Creature* cVictim = (Creature*)uVictim;
-
-            if (!cVictim->IsRacialLeader())
-            {
-                return false;
-            }
-
-            honor = 100;                                    // ??? need more info
-            victim_rank = 19;                               // HK: Leader
-        }
-    }
-
-    if (uVictim != NULL)
-    {
-        honor *= sWorld.getConfig(CONFIG_FLOAT_RATE_HONOR);
-
-        if (groupsize > 1)
-        {
-            honor /= groupsize;
-        }
-
-        honor *= (((float)urand(8, 12)) / 10);              // approx honor: 80% - 120% of real honor
-    }
-
-    // honor - for show honor points in log
-    // victim_guid - for show victim name in log
-    // victim_rank [1..4]  HK: <dishonored rank>
-    // victim_rank [5..19] HK: <alliance\horde rank>
-    // victim_rank [0,20+] HK: <>
-    WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
-    data << uint32(honor);
-    data << ObjectGuid(victim_guid);
-    data << uint32(victim_rank);
-    GetSession()->SendPacket(&data);
-
-    // add honor points
-    ModifyHonorPoints(int32(honor));
-
-    ApplyModUInt32Value(PLAYER_FIELD_TODAY_CONTRIBUTION, uint32(honor), true);
-    return true;
-}
 
 void Player::SetHonorPoints(uint32 value)
 {

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -379,7 +379,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_spellCooldownMgr(this), m_mover(this), m_camera(this), m_reputationMgr(this)
+Player::Player(WorldSession* session): Unit(), m_petMgr(this), m_spellCooldownMgr(this), m_mover(this), m_camera(this), m_reputationMgr(this)
 {
 #ifdef ENABLE_PLAYERBOTS
     m_playerbotAI = 0;
@@ -520,7 +520,7 @@ Player::Player(WorldSession* session): Unit(), m_spellCooldownMgr(this), m_mover
     m_ammoDPS = 0.0f;
 
     // Initialize temporary unsummoned pet number to 0
-    m_temporaryUnsummonedPetNumber = 0;
+    // m_temporaryUnsummonedPetNumber initialized by m_petMgr ctor
 
     //////////////////// Rest System/////////////////////
     // Initialize time of entering inn to 0
@@ -554,7 +554,7 @@ Player::Player(WorldSession* session): Unit(), m_spellCooldownMgr(this), m_mover
     }
 
     // Initialize stable slots to 0
-    m_stableSlots = 0;
+    // m_stableSlots initialized by m_petMgr ctor
 
     /////////////////// Instance System /////////////////////
     // Initialize homebind timer to 0
@@ -4281,18 +4281,6 @@ void Player::SetFFAPvP(bool state)
 }
 
 
-/**
- * @brief Unsummons the player's current pet using the requested save mode.
- *
- * @param mode The persistence mode to use when removing the pet.
- */
-void Player::RemovePet(PetSaveMode mode)
-{
-    if (Pet* pet = GetPet())
-    {
-        pet->Unsummon(mode, this);
-    }
-}
 
 /**
  * @brief Unsummons the player's active mini-pet.
@@ -4328,15 +4316,6 @@ Pet* Player::GetMiniPet() const
 
 
 
-/**
- * @brief Clears the pet action bar on the client.
- */
-void Player::RemovePetActionBar()
-{
-    WorldPacket data(SMSG_PET_SPELLS, 8);
-    data << ObjectGuid();
-    SendDirectMessage(&data);
-}
 
 /**
  * @brief Checks whether a spell modifier currently applies to a spell.
@@ -6175,54 +6154,7 @@ void Player::HandleFall(MovementInfo const& movementInfo)
 
 
 
-/**
- * @brief Temporarily unsummons the current pet when the player's state requires it.
- */
-void Player::UnsummonPetTemporaryIfAny()
-{
-    Pet* pet = GetPet();
-    if (!pet)
-    {
-        return;
-    }
 
-    if (!m_temporaryUnsummonedPetNumber && pet->isControlled() && !pet->isTemporarySummoned())
-    {
-        m_temporaryUnsummonedPetNumber = pet->GetCharmInfo()->GetPetNumber();
-    }
-
-    pet->Unsummon(PET_SAVE_AS_CURRENT, this);
-}
-
-/**
- * @brief Resummons a pet that was temporarily unsummoned earlier.
- */
-void Player::ResummonPetTemporaryUnSummonedIfAny()
-{
-    if (!m_temporaryUnsummonedPetNumber)
-    {
-        return;
-    }
-
-    // not resummon in not appropriate state
-    if (IsPetNeedBeTemporaryUnsummoned())
-    {
-        return;
-    }
-
-    if (GetPetGuid())
-    {
-        return;
-    }
-
-    Pet* NewPet = new Pet;
-    if (!NewPet->LoadPetFromDB(this, 0, m_temporaryUnsummonedPetNumber, true))
-    {
-        delete NewPet;
-    }
-
-    m_temporaryUnsummonedPetNumber = 0;
-}
 
 
 

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -379,7 +379,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_reputationMgr(this)
+Player::Player(WorldSession* session): Unit(), m_spellCooldownMgr(this), m_mover(this), m_camera(this), m_reputationMgr(this)
 {
 #ifdef ENABLE_PLAYERBOTS
     m_playerbotAI = 0;
@@ -2774,7 +2774,7 @@ void Player::SendInitialSpells()
      * * * * * * * * * * * * * * * * */
     uint16 spellCount = 0;
 
-    WorldPacket data(SMSG_INITIAL_SPELLS, (1 + 2 + 4 * m_spells.size() + 2 + m_spellCooldowns.size() * (2 + 2 + 2 + 4 + 4)));
+    WorldPacket data(SMSG_INITIAL_SPELLS, (1 + 2 + 4 * m_spells.size() + 2 + m_spellCooldownMgr.GetSpellCooldownMap().size() * (2 + 2 + 2 + 4 + 4)));
     data << uint8(0);
 
     /* * * * * * * * * * * * * * * * *
@@ -2810,9 +2810,10 @@ void Player::SendInitialSpells()
     data.put<uint16>(countPos, spellCount);                 // write real count value
 
     /* For each spell the player has on cooldown */
-    uint16 spellCooldowns = m_spellCooldowns.size();
+    SpellCooldowns const& spellCooldownMap = m_spellCooldownMgr.GetSpellCooldownMap();
+    uint16 spellCooldowns = spellCooldownMap.size();
     data << uint16(spellCooldowns);
-    for (SpellCooldowns::const_iterator itr = m_spellCooldowns.begin(); itr != m_spellCooldowns.end(); ++itr)
+    for (SpellCooldowns::const_iterator itr = spellCooldownMap.begin(); itr != spellCooldownMap.end(); ++itr)
     {
         /* If the spell doesn't exist in the spellbook, just ignore it */
         SpellEntry const* sEntry = sSpellStore.LookupEntry(itr->first);
@@ -2864,165 +2865,11 @@ void Player::SendInitialSpells()
 
 
 
-/**
- * @brief Removes a cooldown entry for a specific spell.
- *
- * @param spell_id The spell identifier whose cooldown should be removed.
- * @param update True to notify the client that the cooldown was cleared.
- */
-void Player::RemoveSpellCooldown(uint32 spell_id, bool update /* = false */)
-{
-    m_spellCooldowns.erase(spell_id);
 
-    if (update)
-    {
-        SendClearCooldown(spell_id, this);
-    }
-}
 
-/**
- * @brief Removes cooldowns for all spells in a cooldown category.
- *
- * @param cat The spell category identifier.
- * @param update True to notify the client for cleared cooldowns.
- */
-void Player::RemoveSpellCategoryCooldown(uint32 cat, bool update /* = false */)
-{
-    SpellCategoryStore::const_iterator ct = sSpellCategoryStore.find(cat);
-    if (ct == sSpellCategoryStore.end())
-    {
-        return;
-    }
 
-    const SpellCategorySet& ct_set = ct->second;
-    for (SpellCooldowns::const_iterator i = m_spellCooldowns.begin(); i != m_spellCooldowns.end();)
-    {
-        if (ct_set.find(i->first) != ct_set.end())
-        {
-            RemoveSpellCooldown((i++)->first, update);
-        }
-        else
-        {
-            ++i;
-        }
-    }
-}
 
-void Player::RemoveArenaSpellCooldowns()
-{
-    // remove cooldowns on spells that has < 15 min CD
-    SpellCooldowns::iterator itr, next;
-    // iterate spell cooldowns
-    for (itr = m_spellCooldowns.begin(); itr != m_spellCooldowns.end(); itr = next)
-    {
-        next = itr;
-        ++next;
-        SpellEntry const* entry = sSpellStore.LookupEntry(itr->first);
-        // check if spellentry is present and if the cooldown is less than 15 mins
-        if (entry &&
-                entry->RecoveryTime <= 15 * MINUTE * IN_MILLISECONDS &&
-                entry->CategoryRecoveryTime <= 15 * MINUTE * IN_MILLISECONDS)
-        {
-            // remove & notify
-            RemoveSpellCooldown(itr->first, true);
-        }
-    }
-}
 
-/**
- * @brief Clears all tracked spell cooldowns for the player.
- */
-void Player::RemoveAllSpellCooldown()
-{
-    if (!m_spellCooldowns.empty())
-    {
-        for (SpellCooldowns::const_iterator itr = m_spellCooldowns.begin(); itr != m_spellCooldowns.end(); ++itr)
-        {
-            SendClearCooldown(itr->first, this);
-        }
-
-        m_spellCooldowns.clear();
-    }
-}
-
-/**
- * @brief Loads persisted spell cooldowns from the database query result.
- *
- * @param result The query result containing cooldown rows.
- */
-void Player::_LoadSpellCooldowns(QueryResult* result)
-{
-    // some cooldowns can be already set at aura loading...
-
-    // QueryResult *result = CharacterDatabase.PQuery("SELECT `spell`,`item`,`time` FROM `character_spell_cooldown` WHERE `guid` = '%u'",GetGUIDLow());
-
-    if (result)
-    {
-        time_t curTime = time(NULL);
-
-        do
-        {
-            Field* fields = result->Fetch();
-
-            uint32 spell_id = fields[0].GetUInt32();
-            uint32 item_id  = fields[1].GetUInt32();
-            time_t db_time  = (time_t)fields[2].GetUInt64();
-
-            if (!sSpellStore.LookupEntry(spell_id))
-            {
-                sLog.outError("Player %u has unknown spell %u in `character_spell_cooldown`, skipping.", GetGUIDLow(), spell_id);
-                continue;
-            }
-
-            // skip outdated cooldown
-            if (db_time <= curTime)
-            {
-                continue;
-            }
-
-            AddSpellCooldown(spell_id, item_id, db_time);
-
-            DEBUG_LOG("Player (GUID: %u) spell %u, item %u cooldown loaded (%u secs).", GetGUIDLow(), spell_id, item_id, uint32(db_time - curTime));
-        }
-        while (result->NextRow());
-
-        delete result;
-    }
-}
-
-/**
- * @brief Saves active spell cooldowns to the database.
- */
-void Player::_SaveSpellCooldowns()
-{
-    static SqlStatementID deleteSpellCooldown ;
-    static SqlStatementID insertSpellCooldown ;
-
-    SqlStatement stmt = CharacterDatabase.CreateStatement(deleteSpellCooldown, "DELETE FROM `character_spell_cooldown` WHERE `guid` = ?");
-    stmt.PExecute(GetGUIDLow());
-
-    time_t curTime = time(NULL);
-    time_t infTime = curTime + infinityCooldownDelayCheck;
-
-    // remove outdated and save active
-    for (SpellCooldowns::iterator itr = m_spellCooldowns.begin(); itr != m_spellCooldowns.end();)
-    {
-        if (itr->second.end <= curTime)
-        {
-            m_spellCooldowns.erase(itr++);
-        }
-        else if (itr->second.end <= infTime)                // not save locked cooldowns, it will be reset or set at reload
-        {
-            stmt = CharacterDatabase.CreateStatement(insertSpellCooldown, "INSERT INTO `character_spell_cooldown` (`guid`,`spell`,`item`,`time`) VALUES( ?, ?, ?, ?)");
-            stmt.PExecute(GetGUIDLow(), itr->first, itr->second.itemid, uint64(itr->second.end));
-            ++itr;
-        }
-        else
-        {
-            ++itr;
-        }
-    }
-}
 
 
 
@@ -4981,161 +4828,8 @@ bool Player::BuyItemFromVendor(ObjectGuid vendorGuid, uint32 item, uint8 count, 
 
 
 
-/**
- * @brief Applies personal and category cooldowns for a spell cast.
- *
- * @param spellInfo The spell entry that triggered the cooldown.
- * @param itemId The casting item entry, if any.
- * @param spell The active spell instance.
- * @param infinityCooldown True to apply a long-lived cooldown marker.
- */
-void Player::AddSpellAndCategoryCooldowns(SpellEntry const* spellInfo, uint32 itemId, Spell* spell, bool infinityCooldown)
-{
-    // init cooldown values
-    uint32 cat   = 0;
-    int32 rec    = -1;
-    int32 catrec = -1;
 
-    // some special item spells without correct cooldown in SpellInfo
-    // cooldown information stored in item prototype
-    // This used in same way in WorldSession::HandleItemQuerySingleOpcode data sending to client.
 
-    if (itemId)
-    {
-        if (ItemPrototype const* proto = ObjectMgr::GetItemPrototype(itemId))
-        {
-            for (int idx = 0; idx < MAX_ITEM_PROTO_SPELLS; ++idx)
-            {
-                if (proto->Spells[idx].SpellId == spellInfo->Id)
-                {
-                    cat    = proto->Spells[idx].SpellCategory;
-                    rec    = proto->Spells[idx].SpellCooldown;
-                    catrec = proto->Spells[idx].SpellCategoryCooldown;
-                    break;
-                }
-            }
-        }
-    }
-
-    // if no cooldown found above then base at DBC data
-    if (rec < 0 && catrec < 0)
-    {
-        cat = spellInfo->Category;
-        rec = spellInfo->RecoveryTime;
-        catrec = spellInfo->CategoryRecoveryTime;
-    }
-
-    time_t curTime = time(NULL);
-
-    time_t catrecTime;
-    time_t recTime;
-
-    // overwrite time for selected category
-    if (infinityCooldown)
-    {
-        // use +MONTH as infinity mark for spell cooldown (will checked as MONTH/2 at save ans skipped)
-        // but not allow ignore until reset or re-login
-        catrecTime = catrec > 0 ? curTime + infinityCooldownDelay : 0;
-        recTime    = rec    > 0 ? curTime + infinityCooldownDelay : catrecTime;
-    }
-    else
-    {
-        // shoot spells used equipped item cooldown values already assigned in GetAttackTime(RANGED_ATTACK)
-        // prevent 0 cooldowns set by another way
-        if (rec <= 0 && catrec <= 0 && (cat == 76 || cat == 351))
-        {
-            rec = GetAttackTime(RANGED_ATTACK);
-        }
-
-        // Now we have cooldown data (if found any), time to apply mods
-        if (rec > 0)
-        {
-            ApplySpellMod(spellInfo->Id, SPELLMOD_COOLDOWN, rec, spell);
-        }
-
-        if (catrec > 0)
-        {
-            ApplySpellMod(spellInfo->Id, SPELLMOD_COOLDOWN, catrec, spell);
-        }
-
-        // replace negative cooldowns by 0
-        if (rec < 0)
-        {
-            rec = 0;
-        }
-        if (catrec < 0)
-        {
-            catrec = 0;
-        }
-
-        // no cooldown after applying spell mods
-        if (rec == 0 && catrec == 0)
-        {
-            return;
-        }
-
-        catrecTime = catrec ? curTime + catrec / IN_MILLISECONDS : 0;
-        recTime    = rec ? curTime + rec / IN_MILLISECONDS : catrecTime;
-    }
-
-    // self spell cooldown
-    if (recTime > 0)
-    {
-        AddSpellCooldown(spellInfo->Id, itemId, recTime);
-    }
-
-    // category spells
-    if (cat && catrec > 0)
-    {
-        SpellCategoryStore::const_iterator i_scstore = sSpellCategoryStore.find(cat);
-        if (i_scstore != sSpellCategoryStore.end())
-        {
-            for (SpellCategorySet::const_iterator i_scset = i_scstore->second.begin(); i_scset != i_scstore->second.end(); ++i_scset)
-            {
-                if (*i_scset == spellInfo->Id)              // skip main spell, already handled above
-                {
-                    continue;
-                }
-
-                AddSpellCooldown(*i_scset, itemId, catrecTime);
-            }
-        }
-    }
-}
-
-/**
- * @brief Stores a cooldown entry for a spell.
- *
- * @param spellid The spell identifier.
- * @param itemid The associated item identifier, if any.
- * @param end_time The server time when the cooldown ends.
- */
-void Player::AddSpellCooldown(uint32 spellid, uint32 itemid, time_t end_time)
-{
-    SpellCooldown sc;
-    sc.end = end_time;
-    sc.itemid = itemid;
-    m_spellCooldowns[spellid] = sc;
-}
-
-/**
- * @brief Applies cooldowns and notifies the client about a spell cooldown event.
- *
- * @param spellInfo The spell entry that triggered the cooldown.
- * @param itemId The associated item entry, if any.
- * @param spell The active spell instance.
- */
-void Player::SendCooldownEvent(SpellEntry const* spellInfo, uint32 itemId, Spell* spell)
-{
-    // start cooldowns at server side, if any
-    AddSpellAndCategoryCooldowns(spellInfo, itemId, spell);
-
-    // Send activate cooldown timer (possible 0) at client side
-    WorldPacket data(SMSG_COOLDOWN_EVENT, (4 + 8));
-    data << uint32(spellInfo->Id);
-    data << GetObjectGuid();
-    SendDirectMessage(&data);
-}
 
 
 

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -67,6 +67,7 @@
 #include "ReputationMgr.h"
 #include "SpellCooldownMgr.h"                                // held by value on Player; brings in SpellCooldown struct + owns the cooldown map
 #include "PetMgr.h"                                          // held by value on Player; owns stable-slot count + temp-unsummon pet number
+#include "HonorMgr.h"                                        // held by value on Player; owns daily-kill rollover + per-kill honor calc
 #include "BattleGround.h"
 #include "DBCStores.h"
 #include "SharedDefines.h"
@@ -3192,10 +3193,10 @@ class Player : public Unit
         void UpdateArenaFields();
 
         // Update honor fields
-        void UpdateHonorFields();
+        void UpdateHonorFields() { m_honorMgr.UpdateKills(); }
 
         // Reward honor for killing a unit
-        bool RewardHonor(Unit* pVictim, uint32 groupsize, float honor = -1);
+        bool RewardHonor(Unit* pVictim, uint32 groupsize, float honor = -1) { return m_honorMgr.Reward(pVictim, groupsize, honor); }
 
         // Get the player's honor points
         uint32 GetHonorPoints() const { return GetUInt32Value(PLAYER_FIELD_HONOR_CURRENCY); }
@@ -4067,7 +4068,7 @@ class Player : public Unit
         /***                  HONOR SYSTEM                     ***/
         /*********************************************************/
 
-        time_t m_lastHonorUpdateTime; // Last honor update time
+        HonorMgr m_honorMgr; // owns daily-kill rollover + per-kill honor calc
 
         // Output debug stats values
         void outDebugStatsValues() const;

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -66,6 +66,7 @@
 #include "Util.h"                                           // for Tokens typedef
 #include "ReputationMgr.h"
 #include "SpellCooldownMgr.h"                                // held by value on Player; brings in SpellCooldown struct + owns the cooldown map
+#include "PetMgr.h"                                          // held by value on Player; owns stable-slot count + temp-unsummon pet number
 #include "BattleGround.h"
 #include "DBCStores.h"
 #include "SharedDefines.h"
@@ -1438,7 +1439,7 @@ class Player : public Unit
         }
 
         // Remove the player's pet
-        void RemovePet(PetSaveMode mode);
+        void RemovePet(PetSaveMode mode) { m_petMgr.Remove(mode); }
 
         // Remove the player's mini pet
         void RemoveMiniPet();
@@ -1844,7 +1845,7 @@ class Player : public Unit
         // Load the player's pet
         void LoadPet();
 
-        uint32 m_stableSlots; // Number of stable slots
+        PetMgr m_petMgr; // owns stable-slot count + temp-unsummon pet number
 
         /*********************************************************/
         /***                    GOSSIP SYSTEM                  ***/
@@ -2341,7 +2342,7 @@ class Player : public Unit
         void PossessSpellInitialize();
 
         // Remove the pet action bar
-        void RemovePetActionBar();
+        void RemovePetActionBar() { m_petMgr.RemoveActionBar(); }
 
         // Check if the player has a specific spell
         bool HasSpell(uint32 spell) const override;
@@ -3748,10 +3749,13 @@ class Player : public Unit
         LookingForGroup m_lookingForGroup;
 
         // Temporarily removed pet cache
-        uint32 GetTemporaryUnsummonedPetNumber() const { return m_temporaryUnsummonedPetNumber; }
-        void SetTemporaryUnsummonedPetNumber(uint32 petnumber) { m_temporaryUnsummonedPetNumber = petnumber; }
-        void UnsummonPetTemporaryIfAny();
-        void ResummonPetTemporaryUnSummonedIfAny();
+        // Pet-metadata API — thin delegating wrappers around m_petMgr.
+        uint32 GetStableSlots() const { return m_petMgr.GetStableSlots(); }
+        void SetStableSlots(uint32 slots) { m_petMgr.SetStableSlots(slots); }
+        uint32 GetTemporaryUnsummonedPetNumber() const { return m_petMgr.GetTemporaryUnsummonedPetNumber(); }
+        void SetTemporaryUnsummonedPetNumber(uint32 petnumber) { m_petMgr.SetTemporaryUnsummonedPetNumber(petnumber); }
+        void UnsummonPetTemporaryIfAny() { m_petMgr.UnsummonTemporaryIfAny(); }
+        void ResummonPetTemporaryUnSummonedIfAny() { m_petMgr.ResummonTemporaryUnsummonedIfAny(); }
         bool IsPetNeedBeTemporaryUnsummoned() const { return !IsInWorld() || !IsAlive() || IsMounted() /*+in flight*/; }
 
         // Send cinematic start to the client
@@ -4298,8 +4302,7 @@ class Player : public Unit
         // Detect invisibility timer
         uint32 m_DetectInvTimer;
 
-        // Temporary removed pet cache
-        uint32 m_temporaryUnsummonedPetNumber;
+        // Temporary removed pet cache and stable-slot count now owned by m_petMgr.
 
         // Reputation manager for the player
         ReputationMgr  m_reputationMgr;

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -65,6 +65,7 @@
 #include "MapReference.h"
 #include "Util.h"                                           // for Tokens typedef
 #include "ReputationMgr.h"
+#include "SpellCooldownMgr.h"                                // held by value on Player; brings in SpellCooldown struct + owns the cooldown map
 #include "BattleGround.h"
 #include "DBCStores.h"
 #include "SharedDefines.h"
@@ -241,16 +242,7 @@ struct SpellModifier
 
 typedef std::list<SpellModifier*> SpellModList;
 
-/**
- * @brief Structure to hold spell cooldown information
- */
-struct SpellCooldown
-{
-    time_t end;    ///< End time of the cooldown
-    uint16 itemid; ///< Item ID associated with the cooldown
-};
-
-typedef std::map<uint32, SpellCooldown> SpellCooldowns;
+// SpellCooldown struct and SpellCooldowns typedef moved to SpellCooldownMgr.h.
 
 /**
  * @brief Trainer spell state enumeration
@@ -2456,11 +2448,8 @@ class Player : public Unit
             return m_spells;
         }
 
-        // Get the player's spell cooldown map
-        SpellCooldowns const& GetSpellCooldownMap() const
-        {
-            return m_spellCooldowns;
-        }
+        // Spell-cooldown API — thin delegating wrappers around m_spellCooldownMgr.
+        SpellCooldowns const& GetSpellCooldownMap() const { return m_spellCooldownMgr.GetSpellCooldownMap(); }
 
         // Add a spell modifier to the player
         void AddSpellMod(SpellModifier* mod, bool apply);
@@ -2483,38 +2472,22 @@ class Player : public Unit
         static uint32 const infinityCooldownDelay = MONTH; // used for set "infinity cooldowns" for spells and check
         static uint32 const infinityCooldownDelayCheck = MONTH / 2;
 
-        // Check if the player has a spell cooldown
-        bool HasSpellCooldown(uint32 spell_id) const
-        {
-            SpellCooldowns::const_iterator itr = m_spellCooldowns.find(spell_id);
-            return itr != m_spellCooldowns.end() && itr->second.end > time(NULL);
-        }
+        bool HasSpellCooldown(uint32 spell_id) const { return m_spellCooldownMgr.HasSpellCooldown(spell_id); }
 
-        // Get the delay for a spell cooldown
-        time_t GetSpellCooldownDelay(uint32 spell_id) const
-        {
-            SpellCooldowns::const_iterator itr = m_spellCooldowns.find(spell_id);
-            time_t t = time(NULL);
-            return itr != m_spellCooldowns.end() && itr->second.end > t ? itr->second.end - t : 0;
-        }
+        time_t GetSpellCooldownDelay(uint32 spell_id) const { return m_spellCooldownMgr.GetSpellCooldownDelay(spell_id); }
 
-        // Add spell and category cooldowns
-        void AddSpellAndCategoryCooldowns(SpellEntry const* spellInfo, uint32 itemId, Spell* spell = NULL, bool infinityCooldown = false);
+        void AddSpellAndCategoryCooldowns(SpellEntry const* spellInfo, uint32 itemId, Spell* spell = NULL, bool infinityCooldown = false) { m_spellCooldownMgr.AddSpellAndCategoryCooldowns(spellInfo, itemId, spell, infinityCooldown); }
 
-        // Add a spell cooldown
-        void AddSpellCooldown(uint32 spell_id, uint32 itemid, time_t end_time);
+        void AddSpellCooldown(uint32 spell_id, uint32 itemid, time_t end_time) { m_spellCooldownMgr.AddSpellCooldown(spell_id, itemid, end_time); }
 
-        // Send a cooldown event to the client
-        void SendCooldownEvent(SpellEntry const* spellInfo, uint32 itemId = 0, Spell* spell = NULL);
+        void SendCooldownEvent(SpellEntry const* spellInfo, uint32 itemId = 0, Spell* spell = NULL) { m_spellCooldownMgr.SendCooldownEvent(spellInfo, itemId, spell); }
 
         // Prohibit a spell school for a specific duration
         void ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs) override;
 
-        // Remove a spell cooldown
-        void RemoveSpellCooldown(uint32 spell_id, bool update = false);
+        void RemoveSpellCooldown(uint32 spell_id, bool update = false) { m_spellCooldownMgr.RemoveSpellCooldown(spell_id, update); }
 
-        // Remove a spell category cooldown
-        void RemoveSpellCategoryCooldown(uint32 cat, bool update = false);
+        void RemoveSpellCategoryCooldown(uint32 cat, bool update = false) { m_spellCooldownMgr.RemoveSpellCategoryCooldown(cat, update); }
 
         // Send a clear cooldown message to the client
         void SendClearCooldown(uint32 spell_id, Unit* target);
@@ -2525,17 +2498,13 @@ class Player : public Unit
             return m_GlobalCooldownMgr;
         }
 
-        // Remove all arena spell cooldowns
-        void RemoveArenaSpellCooldowns();
+        void RemoveArenaSpellCooldowns() { m_spellCooldownMgr.RemoveArenaSpellCooldowns(); }
 
-        // Remove all spell cooldowns
-        void RemoveAllSpellCooldown();
+        void RemoveAllSpellCooldown() { m_spellCooldownMgr.RemoveAllSpellCooldown(); }
 
-        // Load spell cooldowns from the database
-        void _LoadSpellCooldowns(QueryResult* result);
+        void _LoadSpellCooldowns(QueryResult* result) { m_spellCooldownMgr.LoadFromDB(result); }
 
-        // Save spell cooldowns to the database
-        void _SaveSpellCooldowns();
+        void _SaveSpellCooldowns() { m_spellCooldownMgr.SaveToDB(); }
 
         // Set resurrect request data
         void setResurrectRequestData(ObjectGuid guid, uint32 mapId, float X, float Y, float Z, uint32 health, uint32 mana)
@@ -4130,7 +4099,7 @@ class Player : public Unit
 
         PlayerMails m_mail; // Player mails
         PlayerSpellMap m_spells; // Player spells
-        SpellCooldowns m_spellCooldowns; // Spell cooldowns
+        SpellCooldownMgr m_spellCooldownMgr; // owns the spell-cooldown map + load/save/apply lifecycle
 
         GlobalCooldownMgr m_GlobalCooldownMgr; // Global cooldown manager
 

--- a/src/game/Object/PlayerLoad.cpp
+++ b/src/game/Object/PlayerLoad.cpp
@@ -607,12 +607,7 @@ bool Player::LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder)
 
     uint32 extraflags = fields[31].GetUInt32();
 
-    m_stableSlots = fields[32].GetUInt32();
-    if (m_stableSlots > MAX_PET_STABLES)
-    {
-        sLog.outError("Player can have not more %u stable slots, but have in DB %u", MAX_PET_STABLES, uint32(m_stableSlots));
-        m_stableSlots = MAX_PET_STABLES;
-    }
+    m_petMgr.LoadStableSlotsFromField(fields[32].GetUInt32());
 
     m_atLoginFlags = fields[33].GetUInt32();
 

--- a/src/game/Object/PlayerLoad.cpp
+++ b/src/game/Object/PlayerLoad.cpp
@@ -613,7 +613,7 @@ bool Player::LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder)
 
     // Honor system
     // Update Honor kills data
-    m_lastHonorUpdateTime = logoutTime;
+    m_honorMgr.SetLastKillUpdate(logoutTime);
     UpdateHonorFields();
 
     m_deathExpireTime = (time_t)fields[36].GetUInt64();

--- a/src/game/Object/PlayerSave.cpp
+++ b/src/game/Object/PlayerSave.cpp
@@ -223,7 +223,7 @@ void Player::SaveToDB()
 
     uberInsert.addUInt32(m_ExtraFlags);
 
-    uberInsert.addUInt32(uint32(m_stableSlots));            // to prevent save uint8 as char
+    uberInsert.addUInt32(uint32(GetStableSlots()));         // to prevent save uint8 as char
 
     uberInsert.addUInt32(uint32(m_atLoginFlags));
 

--- a/src/game/Object/SpellCooldownMgr.cpp
+++ b/src/game/Object/SpellCooldownMgr.cpp
@@ -1,0 +1,307 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "SpellCooldownMgr.h"
+#include "Player.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "SpellMgr.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "ObjectMgr.h"
+#include "Spell.h"
+#include "DBCStores.h"
+#include "Database/DatabaseEnv.h"
+#include "Database/DatabaseImpl.h"
+
+void SpellCooldownMgr::AddSpellAndCategoryCooldowns(SpellEntry const* spellInfo, uint32 itemId, Spell* spell, bool infinityCooldown)
+{
+    // init cooldown values
+    uint32 cat   = 0;
+    int32 rec    = -1;
+    int32 catrec = -1;
+
+    // some special item spells without correct cooldown in SpellInfo
+    // cooldown information stored in item prototype
+    // This used in same way in WorldSession::HandleItemQuerySingleOpcode data sending to client.
+
+    if (itemId)
+    {
+        if (ItemPrototype const* proto = ObjectMgr::GetItemPrototype(itemId))
+        {
+            for (int idx = 0; idx < MAX_ITEM_PROTO_SPELLS; ++idx)
+            {
+                if (proto->Spells[idx].SpellId == spellInfo->Id)
+                {
+                    cat    = proto->Spells[idx].SpellCategory;
+                    rec    = proto->Spells[idx].SpellCooldown;
+                    catrec = proto->Spells[idx].SpellCategoryCooldown;
+                    break;
+                }
+            }
+        }
+    }
+
+    // if no cooldown found above then base at DBC data
+    if (rec < 0 && catrec < 0)
+    {
+        cat = spellInfo->Category;
+        rec = spellInfo->RecoveryTime;
+        catrec = spellInfo->CategoryRecoveryTime;
+    }
+
+    time_t curTime = time(NULL);
+
+    time_t catrecTime;
+    time_t recTime;
+
+    // overwrite time for selected category
+    if (infinityCooldown)
+    {
+        // use +MONTH as infinity mark for spell cooldown (will checked as MONTH/2 at save ans skipped)
+        // but not allow ignore until reset or re-login
+        catrecTime = catrec > 0 ? curTime + Player::infinityCooldownDelay : 0;
+        recTime    = rec    > 0 ? curTime + Player::infinityCooldownDelay : catrecTime;
+    }
+    else
+    {
+        // shoot spells used equipped item cooldown values already assigned in GetAttackTime(RANGED_ATTACK)
+        // prevent 0 cooldowns set by another way
+        if (rec <= 0 && catrec <= 0 && (cat == 76 || cat == 351))
+        {
+            rec = m_owner->GetAttackTime(RANGED_ATTACK);
+        }
+
+        // Now we have cooldown data (if found any), time to apply mods
+        if (rec > 0)
+        {
+            m_owner->ApplySpellMod(spellInfo->Id, SPELLMOD_COOLDOWN, rec, spell);
+        }
+
+        if (catrec > 0)
+        {
+            m_owner->ApplySpellMod(spellInfo->Id, SPELLMOD_COOLDOWN, catrec, spell);
+        }
+
+        // replace negative cooldowns by 0
+        if (rec < 0)
+        {
+            rec = 0;
+        }
+        if (catrec < 0)
+        {
+            catrec = 0;
+        }
+
+        // no cooldown after applying spell mods
+        if (rec == 0 && catrec == 0)
+        {
+            return;
+        }
+
+        catrecTime = catrec ? curTime + catrec / IN_MILLISECONDS : 0;
+        recTime    = rec ? curTime + rec / IN_MILLISECONDS : catrecTime;
+    }
+
+    // self spell cooldown
+    if (recTime > 0)
+    {
+        AddSpellCooldown(spellInfo->Id, itemId, recTime);
+    }
+
+    // category spells
+    if (cat && catrec > 0)
+    {
+        SpellCategoryStore::const_iterator i_scstore = sSpellCategoryStore.find(cat);
+        if (i_scstore != sSpellCategoryStore.end())
+        {
+            for (SpellCategorySet::const_iterator i_scset = i_scstore->second.begin(); i_scset != i_scstore->second.end(); ++i_scset)
+            {
+                if (*i_scset == spellInfo->Id)              // skip main spell, already handled above
+                {
+                    continue;
+                }
+
+                AddSpellCooldown(*i_scset, itemId, catrecTime);
+            }
+        }
+    }
+}
+
+void SpellCooldownMgr::AddSpellCooldown(uint32 spellid, uint32 itemid, time_t end_time)
+{
+    SpellCooldown sc;
+    sc.end = end_time;
+    sc.itemid = itemid;
+    m_cooldowns[spellid] = sc;
+}
+
+void SpellCooldownMgr::SendCooldownEvent(SpellEntry const* spellInfo, uint32 itemId, Spell* spell)
+{
+    // start cooldowns at server side, if any
+    AddSpellAndCategoryCooldowns(spellInfo, itemId, spell);
+
+    // Send activate cooldown timer (possible 0) at client side
+    WorldPacket data(SMSG_COOLDOWN_EVENT, (4 + 8));
+    data << uint32(spellInfo->Id);
+    data << m_owner->GetObjectGuid();
+    m_owner->SendDirectMessage(&data);
+}
+
+void SpellCooldownMgr::RemoveSpellCooldown(uint32 spell_id, bool update /* = false */)
+{
+    m_cooldowns.erase(spell_id);
+
+    if (update)
+    {
+        m_owner->SendClearCooldown(spell_id, m_owner);
+    }
+}
+
+void SpellCooldownMgr::RemoveSpellCategoryCooldown(uint32 cat, bool update /* = false */)
+{
+    SpellCategoryStore::const_iterator ct = sSpellCategoryStore.find(cat);
+    if (ct == sSpellCategoryStore.end())
+    {
+        return;
+    }
+
+    const SpellCategorySet& ct_set = ct->second;
+    for (SpellCooldowns::const_iterator i = m_cooldowns.begin(); i != m_cooldowns.end();)
+    {
+        if (ct_set.find(i->first) != ct_set.end())
+        {
+            RemoveSpellCooldown((i++)->first, update);
+        }
+        else
+        {
+            ++i;
+        }
+    }
+}
+
+void SpellCooldownMgr::RemoveArenaSpellCooldowns()
+{
+    // remove cooldowns on spells that has < 15 min CD
+    SpellCooldowns::iterator itr, next;
+    // iterate spell cooldowns
+    for (itr = m_cooldowns.begin(); itr != m_cooldowns.end(); itr = next)
+    {
+        next = itr;
+        ++next;
+        SpellEntry const* entry = sSpellStore.LookupEntry(itr->first);
+        // check if spellentry is present and if the cooldown is less than 15 mins
+        if (entry &&
+                entry->RecoveryTime <= 15 * MINUTE * IN_MILLISECONDS &&
+                entry->CategoryRecoveryTime <= 15 * MINUTE * IN_MILLISECONDS)
+        {
+            // remove & notify
+            RemoveSpellCooldown(itr->first, true);
+        }
+    }
+}
+
+void SpellCooldownMgr::RemoveAllSpellCooldown()
+{
+    if (!m_cooldowns.empty())
+    {
+        for (SpellCooldowns::const_iterator itr = m_cooldowns.begin(); itr != m_cooldowns.end(); ++itr)
+        {
+            m_owner->SendClearCooldown(itr->first, m_owner);
+        }
+
+        m_cooldowns.clear();
+    }
+}
+
+void SpellCooldownMgr::LoadFromDB(QueryResult* result)
+{
+    // some cooldowns can be already set at aura loading...
+
+    // QueryResult *result = CharacterDatabase.PQuery("SELECT `spell`,`item`,`time` FROM `character_spell_cooldown` WHERE `guid` = '%u'",GetGUIDLow());
+
+    if (result)
+    {
+        time_t curTime = time(NULL);
+
+        do
+        {
+            Field* fields = result->Fetch();
+
+            uint32 spell_id = fields[0].GetUInt32();
+            uint32 item_id  = fields[1].GetUInt32();
+            time_t db_time  = (time_t)fields[2].GetUInt64();
+
+            if (!sSpellStore.LookupEntry(spell_id))
+            {
+                sLog.outError("Player %u has unknown spell %u in `character_spell_cooldown`, skipping.", m_owner->GetGUIDLow(), spell_id);
+                continue;
+            }
+
+            // skip outdated cooldown
+            if (db_time <= curTime)
+            {
+                continue;
+            }
+
+            AddSpellCooldown(spell_id, item_id, db_time);
+
+            DEBUG_LOG("Player (GUID: %u) spell %u, item %u cooldown loaded (%u secs).", m_owner->GetGUIDLow(), spell_id, item_id, uint32(db_time - curTime));
+        }
+        while (result->NextRow());
+
+        delete result;
+    }
+}
+
+void SpellCooldownMgr::SaveToDB()
+{
+    static SqlStatementID deleteSpellCooldown ;
+    static SqlStatementID insertSpellCooldown ;
+
+    SqlStatement stmt = CharacterDatabase.CreateStatement(deleteSpellCooldown, "DELETE FROM `character_spell_cooldown` WHERE `guid` = ?");
+    stmt.PExecute(m_owner->GetGUIDLow());
+
+    time_t curTime = time(NULL);
+    time_t infTime = curTime + Player::infinityCooldownDelayCheck;
+
+    // remove outdated and save active
+    for (SpellCooldowns::iterator itr = m_cooldowns.begin(); itr != m_cooldowns.end();)
+    {
+        if (itr->second.end <= curTime)
+        {
+            m_cooldowns.erase(itr++);
+        }
+        else if (itr->second.end <= infTime)                // not save locked cooldowns, it will be reset or set at reload
+        {
+            stmt = CharacterDatabase.CreateStatement(insertSpellCooldown, "INSERT INTO `character_spell_cooldown` (`guid`,`spell`,`item`,`time`) VALUES( ?, ?, ?, ?)");
+            stmt.PExecute(m_owner->GetGUIDLow(), itr->first, itr->second.itemid, uint64(itr->second.end));
+            ++itr;
+        }
+        else
+        {
+            ++itr;
+        }
+    }
+}

--- a/src/game/Object/SpellCooldownMgr.h
+++ b/src/game/Object/SpellCooldownMgr.h
@@ -1,0 +1,88 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_SPELLCOOLDOWNMGR
+#define MANGOS_H_SPELLCOOLDOWNMGR
+
+#include "Common.h"
+#include <map>
+
+class Player;
+class Spell;
+class QueryResult;
+struct SpellEntry;
+
+/**
+ * @brief Structure to hold spell cooldown information
+ */
+struct SpellCooldown
+{
+    time_t end;    ///< End time of the cooldown
+    uint16 itemid; ///< Item ID associated with the cooldown
+};
+
+typedef std::map<uint32, SpellCooldown> SpellCooldowns;
+
+/**
+ * @brief Owns a player's active spell-cooldown map and the operations on it.
+ *
+ * Held by value on Player as m_spellCooldownMgr with a Player* back-pointer.
+ * Persisted to character_spell_cooldown via LoadFromDB()/SaveToDB().
+ */
+class SpellCooldownMgr
+{
+    public:
+        explicit SpellCooldownMgr(Player* owner) : m_owner(owner) {}
+
+        SpellCooldowns const& GetSpellCooldownMap() const { return m_cooldowns; }
+
+        bool HasSpellCooldown(uint32 spell_id) const
+        {
+            SpellCooldowns::const_iterator itr = m_cooldowns.find(spell_id);
+            return itr != m_cooldowns.end() && itr->second.end > time(NULL);
+        }
+
+        time_t GetSpellCooldownDelay(uint32 spell_id) const
+        {
+            SpellCooldowns::const_iterator itr = m_cooldowns.find(spell_id);
+            time_t t = time(NULL);
+            return itr != m_cooldowns.end() && itr->second.end > t ? itr->second.end - t : 0;
+        }
+
+        void AddSpellAndCategoryCooldowns(SpellEntry const* spellInfo, uint32 itemId, Spell* spell = NULL, bool infinityCooldown = false);
+        void AddSpellCooldown(uint32 spell_id, uint32 itemid, time_t end_time);
+        void SendCooldownEvent(SpellEntry const* spellInfo, uint32 itemId = 0, Spell* spell = NULL);
+        void RemoveSpellCooldown(uint32 spell_id, bool update = false);
+        void RemoveSpellCategoryCooldown(uint32 cat, bool update = false);
+        void RemoveArenaSpellCooldowns();
+        void RemoveAllSpellCooldown();
+        void LoadFromDB(QueryResult* result);
+        void SaveToDB();
+
+    private:
+        Player* m_owner;           ///< Non-owning pointer to the owning Player.
+        SpellCooldowns m_cooldowns; ///< Active spell cooldowns keyed by spell id.
+};
+
+#endif // MANGOS_H_SPELLCOOLDOWNMGR

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -734,7 +734,7 @@ void WorldSession::SendStablePet(ObjectGuid guid)
     size_t wpos = data.wpos();
     data << uint8(0);                                       // place holder for slot show number
 
-    data << uint8(GetPlayer()->m_stableSlots);
+    data << uint8(GetPlayer()->GetStableSlots());
 
     uint8 num = 0;                                          // counter for place holder
 
@@ -886,7 +886,7 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
         delete result;
     }
 
-    if (free_slot > 0 && free_slot <= GetPlayer()->m_stableSlots)
+    if (free_slot > 0 && free_slot <= GetPlayer()->GetStableSlots())
     {
         pet->Unsummon(PetSaveMode(free_slot), _player);
         SendStableResult(STABLE_SUCCESS_STABLE);
@@ -997,12 +997,12 @@ void WorldSession::HandleBuyStableSlot(WorldPacket& recv_data)
         GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
-    if (GetPlayer()->m_stableSlots < MAX_PET_STABLES)
+    if (GetPlayer()->GetStableSlots() < MAX_PET_STABLES)
     {
-        StableSlotPricesEntry const* SlotPrice = sStableSlotPricesStore.LookupEntry(GetPlayer()->m_stableSlots + 1);
+        StableSlotPricesEntry const* SlotPrice = sStableSlotPricesStore.LookupEntry(GetPlayer()->GetStableSlots() + 1);
         if (_player->GetMoney() >= SlotPrice->Price)
         {
-            ++GetPlayer()->m_stableSlots;
+            GetPlayer()->SetStableSlots(GetPlayer()->GetStableSlots() + 1);
             _player->ModifyMoney(-int32(SlotPrice->Price));
             SendStableResult(STABLE_SUCCESS_BUY_SLOT);
         }


### PR DESCRIPTION
Ports the MangosTwo manager-extraction decomposition (#233/#234) to MangosOne (TBC 2.4.3): lifts three cohesive concerns off the Player god-object into dedicated manager classes held by value on Player.

**Three managers** (one commit each):
- **SpellCooldownMgr** — owns the active spell-cooldown map + load/save/apply lifecycle
- **PetMgr** — owns the stable-slot count + temporary-unsummon pet number
- **HonorMgr** — owns daily-kill rollover + per-kill honor calc

GlyphMgr and RuneMgr are **not ported** — glyphs and death-knight runes don't exist in 2.4.3.

**Structure from mangostwo, bodies from mangosone.** Each manager takes the sibling fork's class shape, but the method bodies are MangosOne's own — because the logic genuinely differs by expansion and a blind copy would inject WotLK behavior:
- HonorMgr keeps TBC's honor calc — **no achievement-criteria updates**, **no `SPELL_AURA_MOD_HONOR_GAIN` modifier** (both WotLK-only).
- SpellCooldownMgr keeps TBC's ranged-cooldown category check (`cat == 351`) and 4-arg `ApplySpellMod`; there is no `UpdatePotionCooldown` in 2.4.3.

**No behavior change.** Player keeps its full public API (`RewardHonor`, `AddSpellCooldown`, `RemovePet`, `UnsummonPetTemporaryIfAny`, …) as thin inline delegators, so all external call sites are untouched. The stable-purchase economics (gold cost via `StableSlotPricesStore`, `MAX_PET_STABLES` cap) stay in `NPCHandler.cpp`, now reading/writing the slot count through `GetStableSlots()`/`SetStableSlots()`.

Built green with MSVC 2022 (`game` target), Eluna on and off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/142)
<!-- Reviewable:end -->
