### PR TITLE
Fix OpenSSL paths for restricted Windows code pages

### DIFF
--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -172,7 +172,7 @@ bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
     int required = WideCharToMultiByte(
         codePage, flags, value.c_str(), -1,
         nullptr, 0, nullptr, usedDefaultPointer);
-    if (required <= 0 || (!restrictedCodePage && usedDefault))
+    if (required <= 0 || usedDefault)
         return false;
 
     std::vector<char> buffer(static_cast<std::size_t>(required));
@@ -180,7 +180,7 @@ bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
     int written = WideCharToMultiByte(
         codePage, flags, value.c_str(), -1,
         buffer.data(), required, nullptr, usedDefaultPointer);
-    if (written <= 0 || (!restrictedCodePage && usedDefault))
+    if (written <= 0 || usedDefault)
         return false;
 
     converted.assign(buffer.data(), static_cast<std::size_t>(written - 1));

--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -161,19 +161,26 @@ bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
     if (value.empty())
         return false;
 
+    constexpr UINT GB18030_CODE_PAGE = 54936;
+    UINT const codePage = GetACP();
+    bool const restrictedCodePage =
+        codePage == CP_UTF8 || codePage == GB18030_CODE_PAGE;
+    DWORD const flags = restrictedCodePage ?
+        WC_ERR_INVALID_CHARS : WC_NO_BEST_FIT_CHARS;
     BOOL usedDefault = FALSE;
+    BOOL* usedDefaultPointer = restrictedCodePage ? nullptr : &usedDefault;
     int required = WideCharToMultiByte(
-        CP_ACP, WC_NO_BEST_FIT_CHARS, value.c_str(), -1,
-        nullptr, 0, nullptr, &usedDefault);
-    if (required <= 0 || usedDefault)
+        codePage, flags, value.c_str(), -1,
+        nullptr, 0, nullptr, usedDefaultPointer);
+    if (required <= 0 || (!restrictedCodePage && usedDefault))
         return false;
 
     std::vector<char> buffer(static_cast<std::size_t>(required));
     usedDefault = FALSE;
     int written = WideCharToMultiByte(
-        CP_ACP, WC_NO_BEST_FIT_CHARS, value.c_str(), -1,
-        buffer.data(), required, nullptr, &usedDefault);
-    if (written <= 0 || usedDefault)
+        codePage, flags, value.c_str(), -1,
+        buffer.data(), required, nullptr, usedDefaultPointer);
+    if (written <= 0 || (!restrictedCodePage && usedDefault))
         return false;
 
     converted.assign(buffer.data(), static_cast<std::size_t>(written - 1));


### PR DESCRIPTION
## Summary
- use API-valid flags and null default-character pointers when the Windows active code page is UTF-8 or GB18030
- preserve best-fit rejection for other active code pages
- reject malformed UTF-16 rather than silently substituting replacement characters

This is a focused follow-up to #155. No new tests or database changes are included.

## Verification
- Release `mangos_tests` target built
- Release `realmd` target built
- existing OpenSSL tests passed (2/159 selected, 0 failed)
- direct Win32 probes confirmed valid input converts and lone surrogates fail with `ERROR_NO_UNICODE_TRANSLATION` for code pages 65001 and 54936
- Devin SWE-1.7 focused re-review: APPROVE

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/156)
<!-- Reviewable:end -->
