### PR TITLE
[Build] Stop a new commit hash from rebuilding half the tree

### DIFF
--- a/src/game/ChatCommands/ServerCommands.cpp
+++ b/src/game/ChatCommands/ServerCommands.cpp
@@ -41,7 +41,6 @@
 #include "GitRevision.h"
 #include "SystemConfig.h"
 #include "UpdateTime.h"
-#include "revision_data.h"
 #include <cstdlib>
 #include <cstring>
 #include <string>

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -67,7 +67,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerActionButton.cpp
+++ b/src/game/Object/PlayerActionButton.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerAreaTrigger.cpp
+++ b/src/game/Object/PlayerAreaTrigger.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerBattleGround.cpp
+++ b/src/game/Object/PlayerBattleGround.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerChannel.cpp
+++ b/src/game/Object/PlayerChannel.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerCombo.cpp
+++ b/src/game/Object/PlayerCombo.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerDbLookup.cpp
+++ b/src/game/Object/PlayerDbLookup.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerDeath.cpp
+++ b/src/game/Object/PlayerDeath.cpp
@@ -66,7 +66,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerDuel.cpp
+++ b/src/game/Object/PlayerDuel.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerDurability.cpp
+++ b/src/game/Object/PlayerDurability.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerEnchant.cpp
+++ b/src/game/Object/PlayerEnchant.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerGossip.cpp
+++ b/src/game/Object/PlayerGossip.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerGroup.cpp
+++ b/src/game/Object/PlayerGroup.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerInstance.cpp
+++ b/src/game/Object/PlayerInstance.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerItem.cpp
+++ b/src/game/Object/PlayerItem.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerItemApply.cpp
+++ b/src/game/Object/PlayerItemApply.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerLearn.cpp
+++ b/src/game/Object/PlayerLearn.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerLoad.cpp
+++ b/src/game/Object/PlayerLoad.cpp
@@ -68,7 +68,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerLoot.cpp
+++ b/src/game/Object/PlayerLoot.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerMail.cpp
+++ b/src/game/Object/PlayerMail.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerMirror.cpp
+++ b/src/game/Object/PlayerMirror.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerMovement.cpp
+++ b/src/game/Object/PlayerMovement.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerPvP.cpp
+++ b/src/game/Object/PlayerPvP.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerRegen.cpp
+++ b/src/game/Object/PlayerRegen.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerReputation.cpp
+++ b/src/game/Object/PlayerReputation.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerRest.cpp
+++ b/src/game/Object/PlayerRest.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerReward.cpp
+++ b/src/game/Object/PlayerReward.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerSave.cpp
+++ b/src/game/Object/PlayerSave.cpp
@@ -67,7 +67,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerSpell.cpp
+++ b/src/game/Object/PlayerSpell.cpp
@@ -64,7 +64,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerStats.cpp
+++ b/src/game/Object/PlayerStats.cpp
@@ -65,7 +65,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerTalent.cpp
+++ b/src/game/Object/PlayerTalent.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerVendor.cpp
+++ b/src/game/Object/PlayerVendor.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerVisibility.cpp
+++ b/src/game/Object/PlayerVisibility.cpp
@@ -63,7 +63,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/game/Object/PlayerZone.cpp
+++ b/src/game/Object/PlayerZone.cpp
@@ -65,7 +65,6 @@
 #include "OutdoorPvP/OutdoorPvP.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
-#include "revision_data.h"
 #include "Spell.h"
 #include "ScriptMgr.h"
 #include "SocialMgr.h"

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -175,7 +175,32 @@ bool Master::StartDatabases()
         return false;
     }
 
-    sLog.outString("Realm running as realm ID %u", realmID);
+    // The console header is stamped HERE, not where the UI starts: that runs before this
+    // function and would read realmID while it is still its initialiser, which is how it
+    // came to say "realm 0". The name is worth the one query -- an id alone tells you
+    // nothing when several realms share a box.
+    std::string realmName;
+    {
+        std::unique_ptr<QueryResult> result(LoginDatabase.PQuery(
+            "SELECT `name` FROM `realmlist` WHERE `id` = '%u'", realmID));
+        if (result)
+        {
+            realmName = (*result)[0].GetCppString();
+        }
+    }
+
+    MaNGOS::Console::ConsoleUI::Instance().SetHeaderRight(
+        realmName.empty() ? ("realm " + std::to_string(realmID))
+                          : (realmName + " (realm " + std::to_string(realmID) + ")"));
+
+    if (realmName.empty())
+    {
+        sLog.outError("Realm ID %u has no row in `realmlist`; the client will not list it.",
+                      realmID);
+    }
+
+    sLog.outString("Realm running as realm ID %u (%s)", realmID,
+                   realmName.empty() ? "unnamed" : realmName.c_str());
     return true;
 }
 

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -358,8 +358,8 @@ int main(int argc, char** argv)
     if (consoleStyle != "plain" &&
         MaNGOS::Console::ConsoleUI::Instance().Start("MaNGOS One", "TBC 2.4.3"))
     {
-        MaNGOS::Console::ConsoleUI::Instance().SetHeaderRight(
-            std::string("realm ") + std::to_string(realmID));
+        // No realm stamp here: realmID is still 0 until Master::_StartDB reads the config,
+        // which happens after this. It sets the header itself, with the name.
         MaNGOS::Console::ConsoleUI::Instance().SetHint(
             "PgUp/PgDn scroll \xC2\xB7 Ctrl+L redraw");
         MaNGOS::Console::ConsoleUI::Instance().SetKeyEcho(

--- a/src/shared/Common/GitRevision.cpp
+++ b/src/shared/Common/GitRevision.cpp
@@ -25,6 +25,10 @@
 
 #include "GitRevision.h"
 
+// The generated header lands HERE and nowhere else: it changes on every commit, and
+// anything that includes it is rebuilt with it.
+#include "revision_data.h"
+
 char const* GitRevision::GetHash()
 {
     return REVISION_HASH;

--- a/src/shared/Common/GitRevision.h
+++ b/src/shared/Common/GitRevision.h
@@ -29,10 +29,8 @@
 #include "Define.h"
 
 // Included here rather than in GitRevision.cpp on purpose: this header is the
-// one place the generated revision_data.h is meant to be reached through, so
 // that the ~40 translation units that merely want a version string do not each
 // take a dependency on a file the build regenerates.
-#include "revision_data.h"
 
 namespace GitRevision
 {


### PR DESCRIPTION
revision_data.h is regenerated whenever the SHA changes, which is every commit and every pull. 37 files included it, so every one of them was rebuilt with it.

Almost none of them use it. Of the 33 macros the header defines, exactly four are referenced outside GitRevision.cpp, all of them in PlayerQuest.cpp. The other 35 includes are dead: they came from the Player.cpp split, which copied the include into every fragment.

Two changes. The 35 dead includes are gone. And GitRevision.h, the only header in the set and therefore the one that spread the dependency transitively, no longer includes it -- the header declares functions and needs no macros, so the include moves to GitRevision.cpp.

A new hash now rebuilds GitRevision.cpp and PlayerQuest.cpp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosone/server/160)
<!-- Reviewable:end -->
